### PR TITLE
Rework inferring of CommandOptionType

### DIFF
--- a/lib/nyxx_commands.dart
+++ b/lib/nyxx_commands.dart
@@ -12,6 +12,7 @@ export 'src/converter.dart'
         Converter,
         CombineConverter,
         FallbackConverter,
+        // ignore: deprecated_member_use_from_same_package
         discordTypes,
         boolConverter,
         categoryGuildChannelConverter,

--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -397,7 +397,9 @@ class Command with GroupMixin {
         choices ??= argumentConverter?.choices;
 
         options.add(CommandOptionBuilder(
-          argumentConverter?.type ?? CommandOptionType.string,
+          argumentConverter?.type ??
+              discordTypes[mirror.type.reflectedType] ??
+              CommandOptionType.string,
           name,
           _mappedDescriptions[name]!.value,
           required: !mirror.isOptional,

--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -390,12 +390,14 @@ class Command with GroupMixin {
           name = convertToKebabCase(rawArgumentName);
         }
 
+        Converter<dynamic>? argumentConverter = commands.converterFor(mirror.type.reflectedType);
+
         Iterable<ArgChoiceBuilder>? choices = _mappedChoices[name]?.builders;
 
-        choices ??= commands.converterFor(mirror.type.reflectedType)?.choices;
+        choices ??= argumentConverter?.choices;
 
         options.add(CommandOptionBuilder(
-          discordTypes[mirror.type.reflectedType] ?? CommandOptionType.string,
+          argumentConverter?.type ?? CommandOptionType.string,
           name,
           _mappedDescriptions[name]!.value,
           required: !mirror.isOptional,


### PR DESCRIPTION
# Description
This PR changes the way that the `CommandOptionType` for a specific argument is determined.

For starters, the `CommandOptionType` used no longer depends on the type of the argument itself but on the `Converter` used for that type. `Converter`s can now be created with an additional `type` parameter to indicate what `CommandOptionType` to use when this `Converter` is used.

~~Secondly, adding `Type`s to the `discordTypes` map no longer changes which `CommandOptionType` will be used for that `Type`. The map has been marked as deprecated and can be removed in a future update.~~
Secondly, the `discordTypes` map should no longer be used, and as such has been marked deprecated and can be removed in a future update.

Closes #2 
Closes #5 

## Type of change

Please delete options that are not relevant.

~~- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)~~

~~While this change is technically breaking, it does not cause any compilation errors and bots using the framework should continue working. To get the full functionality back, users will have to add the `type` parameter to their `Converters` for custom types.~~
~~Note that if using `CombineConverters` or `FallbackConverters` the type can sometimes be inferred from the converters used within the converter.~~


- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
