### PR TITLE
Fix invalid argument types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+__Bug fixes__:
+- Fixed an issue where `Check.all`, `Check.any` and `Check.deny` would not accept `AbstractCheck`s as arguments.
+
 ## 3.1.0
 __New features__:
 - Default choices for `CombineConverter`s and `FallbackConverter`s can now be specified in the `choices` parameter

--- a/lib/src/checks.dart
+++ b/lib/src/checks.dart
@@ -67,11 +67,11 @@ class Check extends AbstractCheck {
   Check(this._check, [String name = 'Check']) : super(name);
 
   /// Creates a new [Check] that succeeds if at least one of the supplied checks succeed.
-  factory Check.any(Iterable<Check> checks, [String? name]) => _AnyCheck(checks, name);
+  factory Check.any(Iterable<AbstractCheck> checks, [String? name]) => _AnyCheck(checks, name);
 
   /// Creates a new [Check] that inverts the result of the supplied check. Use this to allow use of
   /// commands by default but deny it for certain users.
-  factory Check.deny(Check check, [String? name]) => _DenyCheck(check, name);
+  factory Check.deny(AbstractCheck check, [String? name]) => _DenyCheck(check, name);
 
   /// Creates a new [Check] that succeeds if all of the supplied checks succeeds, and fails
   /// otherwise.
@@ -80,7 +80,7 @@ class Check extends AbstractCheck {
   /// be used to group common patterns of checks together.
   ///
   /// Stateful checks in [checks] will share their state for all uses of this check group.
-  factory Check.all(Iterable<Check> checks, [String? name]) => _GroupCheck(checks, name);
+  factory Check.all(Iterable<AbstractCheck> checks, [String? name]) => _GroupCheck(checks, name);
 
   @override
   FutureOr<bool> check(Context context) => _check(context);
@@ -96,7 +96,7 @@ class Check extends AbstractCheck {
 }
 
 class _AnyCheck extends Check {
-  Iterable<Check> checks;
+  Iterable<AbstractCheck> checks;
 
   _AnyCheck(this.checks, [String? name])
       : super((context) async {
@@ -132,7 +132,7 @@ class _AnyCheck extends Check {
 }
 
 class _DenyCheck extends Check {
-  final Check source;
+  final AbstractCheck source;
 
   _DenyCheck(this.source, [String? name])
       : super((context) async => !(await source.check(context)), name ?? 'Denied ${source.name}');
@@ -157,7 +157,7 @@ class _DenyCheck extends Check {
 }
 
 class _GroupCheck extends Check {
-  final Iterable<Check> checks;
+  final Iterable<AbstractCheck> checks;
 
   _GroupCheck(this.checks, [String? name])
       : super((context) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx_commands
-version: 3.1.0
+version: 3.1.1
 description: A framework for easily creating slash commands and text commands for Discord using the nyxx library.
 
 homepage: https://github.com/nyxx-discord/nyxx_commands/blob/main/README.md


### PR DESCRIPTION
# Description
Fixes a bug where cooldown checks could not be used in check modifiers/combiners due to the argument type being `Check` and not `AbstractCheck`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
