### PR TITLE
Correctly handle call hooks in check modifiers

### DIFF
--- a/lib/src/checks.dart
+++ b/lib/src/checks.dart
@@ -205,6 +205,15 @@ class _DenyCheck extends Check {
           .map((e) => CommandPermissionBuilderAbstract.user(e.id, hasPermission: !e.hasPermission)),
     ];
   }
+
+  // It may seem counterintuitive to call the success hooks if the source check failed, and this is
+  // a situation where there is no proper solution. Here, we assume that the source check will
+  // reset its state on failure after failure, so calling the hooks is desireable.
+  @override
+  Iterable<void Function(Context)> get preCallHooks => source.preCallHooks;
+
+  @override
+  Iterable<void Function(Context)> get postCallHooks => source.postCallHooks;
 }
 
 class _GroupCheck extends Check {

--- a/lib/src/checks.dart
+++ b/lib/src/checks.dart
@@ -74,6 +74,10 @@ class Check extends AbstractCheck {
 
   /// Creates a new [Check] that inverts the result of the supplied check. Use this to allow use of
   /// commands by default but deny it for certain users.
+  ///
+  /// Passing custom checks directly implementing [AbstractCheck] should be done with care, as pre-
+  /// and post- call hooks will be called if the internal check *fails*, and uncalled if the
+  /// internal check *succeeds*.
   factory Check.deny(AbstractCheck check, [String? name]) => _DenyCheck(check, name);
 
   /// Creates a new [Check] that succeeds if all of the supplied checks succeeds, and fails


### PR DESCRIPTION
# Description
Previously pre- and post- call hooks defined on checks were not called from `Check.any`, `Check.all` or `Check.deny`. This PR fixes that bug.

Closes #15 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
