### PR TITLE
Add remaining method to CooldownCheck

### DIFF
--- a/lib/src/checks.dart
+++ b/lib/src/checks.dart
@@ -579,6 +579,38 @@ class CooldownCheck extends AbstractCheck {
     return Object.hashAll(keys);
   }
 
+  /// Get the remaining cooldown time for a context.
+  ///
+  /// If the context is not on cooldown, [Duration.zero] is returned.
+  Duration remaining(Context context) {
+    if (DateTime.now().isAfter(_currentStart.add(duration))) {
+      _previousBucket = _currentBucket;
+      _currentBucket = {};
+
+      _currentStart = DateTime.now();
+    }
+
+    if (check(context) as bool) {
+      return Duration.zero;
+    }
+
+    int key = getKey(context);
+
+    if (_currentBucket.containsKey(key)) {
+      DateTime end = _currentBucket[key]!.start.add(duration);
+
+      return end.difference(DateTime.now());
+    }
+
+    if (_previousBucket.containsKey(key)) {
+      DateTime end = _previousBucket[key]!.start.add(duration);
+
+      return end.difference(DateTime.now());
+    }
+
+    return Duration.zero;
+  }
+
   @override
   late Iterable<void Function(Context)> preCallHooks = [
     (context) {

--- a/lib/src/checks.dart
+++ b/lib/src/checks.dart
@@ -583,7 +583,9 @@ class CooldownCheck extends AbstractCheck {
   ///
   /// If the context is not on cooldown, [Duration.zero] is returned.
   Duration remaining(Context context) {
-    if (DateTime.now().isAfter(_currentStart.add(duration))) {
+    DateTime now = DateTime.now();
+
+    if (now.isAfter(_currentStart.add(duration))) {
       _previousBucket = _currentBucket;
       _currentBucket = {};
 
@@ -595,17 +597,16 @@ class CooldownCheck extends AbstractCheck {
     }
 
     int key = getKey(context);
-
     if (_currentBucket.containsKey(key)) {
       DateTime end = _currentBucket[key]!.start.add(duration);
 
-      return end.difference(DateTime.now());
+      return end.difference(now);
     }
 
     if (_previousBucket.containsKey(key)) {
       DateTime end = _previousBucket[key]!.start.add(duration);
 
-      return end.difference(DateTime.now());
+      return end.difference(now);
     }
 
     return Duration.zero;

--- a/lib/src/checks.dart
+++ b/lib/src/checks.dart
@@ -583,18 +583,11 @@ class CooldownCheck extends AbstractCheck {
   ///
   /// If the context is not on cooldown, [Duration.zero] is returned.
   Duration remaining(Context context) {
-    DateTime now = DateTime.now();
-
-    if (now.isAfter(_currentStart.add(duration))) {
-      _previousBucket = _currentBucket;
-      _currentBucket = {};
-
-      _currentStart = DateTime.now();
-    }
-
     if (check(context) as bool) {
       return Duration.zero;
     }
+
+    DateTime now = DateTime.now();
 
     int key = getKey(context);
     if (_currentBucket.containsKey(key)) {


### PR DESCRIPTION
# Description

Add a method to `CooldownCheck` allowing users to get the time remaining on a cooldown, useful for sending error messages.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
