### PR TITLE
Add support for user Application Commands

### DIFF
--- a/lib/nyxx_commands.dart
+++ b/lib/nyxx_commands.dart
@@ -5,9 +5,9 @@ library nyxx_commands;
 export 'src/checks/checks.dart'
     show AbstractCheck, Check, GuildCheck, RoleCheck, UserCheck, CooldownCheck, CooldownType;
 export 'src/commands.dart' show CommandsPlugin;
-export 'src/commands/chat_command.dart' show ChatCommand, CommandType, commandNameRegexp;
+export 'src/commands/chat_command.dart' show ChatCommand, CommandType;
 export 'src/commands/group.dart' show Group, GroupMixin;
-export 'src/context/chat_context.dart' show ChatContext, InteractionContext, MessageChatContext;
+export 'src/context/chat_context.dart' show ChatContext, InteractionChatContext, MessageChatContext;
 export 'src/converters/converter.dart'
     show
         Converter,
@@ -44,5 +44,13 @@ export 'src/errors.dart'
         UncaughtException;
 export 'src/options.dart' show CommandsOptions;
 export 'src/util/util.dart'
-    show Choices, Description, Name, UseConverter, convertToKebabCase, mentionOr, dmOr;
+    show
+        Choices,
+        Description,
+        Name,
+        UseConverter,
+        convertToKebabCase,
+        mentionOr,
+        dmOr,
+        commandNameRegexp;
 export 'src/util/view.dart' show StringView;

--- a/lib/src/commands/chat_command.dart
+++ b/lib/src/commands/chat_command.dart
@@ -138,9 +138,6 @@ enum CommandType {
   all,
 }
 
-/// A [RegExp] that all command names must match
-final RegExp commandNameRegexp = RegExp(r'^[\w-]{1,32}$', unicode: true);
-
 class SlashCommandImpl with GroupMixin implements ChatCommand {
   @override
   final String name;

--- a/lib/src/commands/chat_command.dart
+++ b/lib/src/commands/chat_command.dart
@@ -150,6 +150,7 @@ class SlashCommandImpl with GroupMixin implements ChatCommand {
 
   @override
   final CommandType type;
+
   @override
   final Function execute;
 

--- a/lib/src/commands/command.dart
+++ b/lib/src/commands/command.dart
@@ -1,9 +1,7 @@
 import 'package:nyxx_commands/src/checks/checks.dart';
 import 'package:nyxx_commands/src/context/context.dart';
 
-/// The base command class. All commands created by `nyxx_commands`, whether they be slash, user,
-/// message or text commands inherit from this class.
-abstract class Command {
+abstract class CommandComponent {
   /// The name of this command.
   ///
   /// This must match [commandNameRegex] and be composed of the lowercase variant of letters where
@@ -20,20 +18,24 @@ abstract class Command {
   /// Add a check to this command.
   void check(AbstractCheck check);
 
+  /// A [Stream] of [Context]s that emits after the checks have succeeded, but before
+  /// [Command.execute] is called.
+  Stream<Context> get onPreCall;
+
+  /// A [Stream] of [Context]s that emits after [Command.execute] has successfully been called (no
+  /// exceptions were thrown).
+  Stream<Context> get onPostCall;
+}
+
+/// The base command class. All commands created by `nyxx_commands`, whether they be slash, user,
+/// message or text commands inherit from this class.
+abstract class Command implements CommandComponent {
   /// The callback function for this command.
   ///
   /// The first argument to this function must be a [Context]. Slash and text commands might have
   /// additional parameter and optional parameter, but user and message commands may not have
   /// additional parameter.
   Function get execute;
-
-  /// A [Stream] of [Context]s that emits after the checks have succeeded, but before
-  /// [execute] is called.
-  Stream<Context> get onPreCall;
-
-  /// A [Stream] of [Context]s that emits after [execute] has successfully been called (no
-  /// exceptions were thrown).
-  Stream<Context> get onPostCall;
 
   /// The function called to invoke the command.
   Future<void> invoke(Context context);

--- a/lib/src/commands/command.dart
+++ b/lib/src/commands/command.dart
@@ -17,12 +17,23 @@ abstract class Command {
   /// An [Iterable] of checks that must succeed for this command to be executed.
   Iterable<AbstractCheck> get checks;
 
+  /// Add a check to this command.
+  void check(AbstractCheck check);
+
   /// The callback function for this command.
   ///
   /// The first argument to this function must be a [Context]. Slash and text commands might have
   /// additional parameter and optional parameter, but user and message commands may not have
   /// additional parameter.
   Function get execute;
+
+  /// A [Stream] of [Context]s that emits after the checks have succeeded, but before
+  /// [execute] is called.
+  Stream<Context> get onPreCall;
+
+  /// A [Stream] of [Context]s that emits after [execute] has successfully been called (no
+  /// exceptions were thrown).
+  Stream<Context> get onPostCall;
 
   /// The function called to invoke the command.
   Future<void> invoke(Context context);

--- a/lib/src/commands/group.dart
+++ b/lib/src/commands/group.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:nyxx_commands/src/util/util.dart';
 import 'package:nyxx_interactions/nyxx_interactions.dart';
 
 import '../checks/checks.dart';

--- a/lib/src/commands/group.dart
+++ b/lib/src/commands/group.dart
@@ -62,12 +62,8 @@ mixin GroupMixin {
   // ignore: public_member_api_docs
   final StreamController<ChatContext> postCallController = StreamController.broadcast();
 
-  /// A [Stream] of [ChatContext]s that emits after the checks have succeeded, but before
-  /// [ChatCommand.execute] is called.
   late final Stream<ChatContext> onPreCall = preCallController.stream;
 
-  /// A [Stream] of [ChatContext]s that emits after [ChatCommand.execute] has successfully been called (no
-  /// exceptions were thrown).
   late final Stream<ChatContext> onPostCall = postCallController.stream;
 
   final List<AbstractCheck> _checks = [];
@@ -214,7 +210,6 @@ mixin GroupMixin {
     return options;
   }
 
-  /// Add a check to this groups [checks].
   void check(AbstractCheck check) {
     _checks.add(check);
 

--- a/lib/src/commands/group.dart
+++ b/lib/src/commands/group.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:nyxx_commands/src/commands/command.dart';
 import 'package:nyxx_commands/src/util/util.dart';
 import 'package:nyxx_interactions/nyxx_interactions.dart';
 
@@ -29,7 +30,7 @@ import 'chat_command.dart';
 ///
 /// All [Group]s, [ChatCommand]s and [CommandsPlugin]s use this mixin to enable nesting and registration
 /// of commands.
-mixin GroupMixin {
+mixin GroupMixin implements CommandComponent {
   /// A mapping of child names to children.
   ///
   /// Used for easier lookup of children based on both [name] and [aliases].
@@ -62,8 +63,10 @@ mixin GroupMixin {
   // ignore: public_member_api_docs
   final StreamController<ChatContext> postCallController = StreamController.broadcast();
 
+  @override
   late final Stream<ChatContext> onPreCall = preCallController.stream;
 
+  @override
   late final Stream<ChatContext> onPostCall = postCallController.stream;
 
   final List<AbstractCheck> _checks = [];

--- a/lib/src/commands/user_command.dart
+++ b/lib/src/commands/user_command.dart
@@ -9,6 +9,13 @@ import 'package:nyxx_commands/src/errors.dart';
 abstract class UserCommand implements Command {
   @override
   Function(UserContext) get execute;
+
+  factory UserCommand(
+    String name,
+    Function(UserContext) execute, {
+    Iterable<AbstractCheck> checks = const [],
+  }) =>
+      UserCommandImpl(name, execute, checks: checks);
 }
 
 class UserCommandImpl implements UserCommand {

--- a/lib/src/commands/user_command.dart
+++ b/lib/src/commands/user_command.dart
@@ -16,7 +16,7 @@ class UserCommandImpl implements UserCommand {
   final String name;
 
   @override
-  final String description;
+  String get description => '';
 
   @override
   final Function(UserContext) execute;
@@ -35,7 +35,6 @@ class UserCommandImpl implements UserCommand {
 
   UserCommandImpl(
     this.name,
-    this.description,
     this.execute, {
     Iterable<AbstractCheck> checks = const [],
   }) {

--- a/lib/src/commands/user_command.dart
+++ b/lib/src/commands/user_command.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import 'package:nyxx_commands/src/checks/checks.dart';
+import 'package:nyxx_commands/src/commands/command.dart';
+import 'package:nyxx_commands/src/context/context.dart';
+import 'package:nyxx_commands/src/context/user_context.dart';
+import 'package:nyxx_commands/src/errors.dart';
+
+abstract class UserCommand implements Command {
+  @override
+  Function(UserContext) get execute;
+}
+
+class UserCommandImpl implements UserCommand {
+  @override
+  final String name;
+
+  @override
+  final String description;
+
+  @override
+  final Function(UserContext) execute;
+
+  @override
+  final List<AbstractCheck> checks = [];
+
+  final StreamController<UserContext> preCallController = StreamController.broadcast();
+  final StreamController<UserContext> postCallController = StreamController.broadcast();
+
+  @override
+  late final Stream<UserContext> onPreCall = preCallController.stream;
+
+  @override
+  late final Stream<UserContext> onPostCall = postCallController.stream;
+
+  UserCommandImpl(
+    this.name,
+    this.description,
+    this.execute, {
+    Iterable<AbstractCheck> checks = const [],
+  }) {
+    for (final check in checks) {
+      this.check(check);
+    }
+  }
+
+  @override
+  Future<void> invoke(Context context) async {
+    if (context is! UserContext) {
+      return;
+    }
+
+    for (final check in checks) {
+      if (!await check.check(context)) {
+        throw CheckFailedException(check, context);
+      }
+    }
+
+    preCallController.add(context);
+
+    try {
+      await execute(context);
+    } on Exception catch (e) {
+      throw UncaughtException(e, context);
+    }
+
+    postCallController.add(context);
+  }
+
+  @override
+  void check(AbstractCheck check) {
+    checks.add(check);
+
+    for (final preCallHook in check.preCallHooks) {
+      onPreCall.listen(preCallHook);
+    }
+
+    for (final postCallHook in check.postCallHooks) {
+      onPostCall.listen(postCallHook);
+    }
+  }
+}

--- a/lib/src/context/chat_context.dart
+++ b/lib/src/context/chat_context.dart
@@ -117,7 +117,7 @@ class MessageChatContext extends ChatContext {
 }
 
 /// Represents a [ChatContext] triggered by a slash command ([ISlashCommandInteraction]).
-class InteractionChatContext extends ChatContext with InteractionContext {
+class InteractionChatContext with InteractionContext implements ChatContext {
   /// The raw arguments received from the API, mapped by name to value.
   final Map<String, dynamic> rawArguments;
 

--- a/lib/src/context/interaction_context.dart
+++ b/lib/src/context/interaction_context.dart
@@ -2,7 +2,7 @@ import 'package:nyxx/nyxx.dart';
 import 'package:nyxx_commands/src/context/context.dart';
 import 'package:nyxx_interactions/nyxx_interactions.dart';
 
-mixin InteractionContext on Context {
+mixin InteractionContext implements Context {
   /// The [ISlashCommandInteraction] that triggered this context's execution.
   ISlashCommandInteraction get interaction;
 

--- a/lib/src/context/user_context.dart
+++ b/lib/src/context/user_context.dart
@@ -1,0 +1,57 @@
+import 'package:nyxx/nyxx.dart';
+import 'package:nyxx_commands/src/commands.dart';
+import 'package:nyxx_commands/src/commands/user_command.dart';
+import 'package:nyxx_commands/src/context/context.dart';
+import 'package:nyxx_commands/src/context/interaction_context.dart';
+import 'package:nyxx_interactions/src/models/interaction.dart';
+import 'package:nyxx_interactions/src/events/interaction_event.dart';
+
+/// Represents a [Context] in which a [UserCommand] was executed.
+class UserContext extends Context with InteractionContext {
+  /// The target member for this context.
+  final IMember? targetMember;
+
+  /// The target user for this context, or the user representing [targetMember].
+  final IUser targetUser;
+
+  @override
+  final ITextChannel channel;
+
+  @override
+  final INyxx client;
+
+  @override
+  final UserCommand command;
+
+  @override
+  final CommandsPlugin commands;
+
+  @override
+  final IGuild? guild;
+
+  @override
+  final IMember? member;
+
+  @override
+  final IUser user;
+
+  @override
+  final ISlashCommandInteraction interaction;
+
+  @override
+  final ISlashCommandInteractionEvent interactionEvent;
+
+  UserContext({
+    required this.targetMember,
+    required this.targetUser,
+    required this.channel,
+    required this.client,
+    required this.command,
+    required this.commands,
+    required this.guild,
+    required this.member,
+    required this.user,
+    required this.interaction,
+    required this.interactionEvent,
+  });
+}

--- a/lib/src/context/user_context.dart
+++ b/lib/src/context/user_context.dart
@@ -54,4 +54,7 @@ class UserContext extends Context with InteractionContext {
     required this.interaction,
     required this.interactionEvent,
   });
+
+  @override
+  String toString() => 'UserContext[interaction=${interaction.token}, target=$targetUser]';
 }

--- a/lib/src/util/util.dart
+++ b/lib/src/util/util.dart
@@ -186,3 +186,6 @@ String Function(IMessage) dmOr(String Function(IMessage) defaultPrefix) {
     return '';
   };
 }
+
+/// A [RegExp] that all command names must match
+final RegExp commandNameRegexp = RegExp(r'^[\w-]{1,32}$', unicode: true);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   logging: ^1.0.2
   meta: ^1.7.0
   nyxx: ^3.0.0
-  nyxx_interactions: ^3.1.0
+  nyxx_interactions: ^3.3.0
 
 dev_dependencies:
   build_runner: ^2.1.4


### PR DESCRIPTION
# Description

This PR adds support for User Commands within `nyxx_commands`.

Examples do not work and will be fixed when the update is nearer to completion.

Closes #23.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
