### PR TITLE
Update with_mirrors.dart

### DIFF
--- a/lib/src/mirror_utils/with_mirrors.dart
+++ b/lib/src/mirror_utils/with_mirrors.dart
@@ -89,7 +89,7 @@ FunctionData loadFunctionData(Function fn) {
       type,
       parameterMirror.isOptional,
       description,
-      parameterMirror.defaultValue,
+      parameterMirror.defaultValue.reflectee,
       choices,
       converterOverride,
     ));


### PR DESCRIPTION
Fixed a bug where it was throwing an error when an optional parameter was not entered in slash command.