### PR TITLE
Add support for attachment arguments

### DIFF
--- a/lib/nyxx_commands.dart
+++ b/lib/nyxx_commands.dart
@@ -37,6 +37,7 @@ export 'src/converters/converter.dart'
         CombineConverter,
         Converter,
         FallbackConverter,
+        attachmentConverter,
         boolConverter,
         categoryGuildChannelConverter,
         doubleConverter,


### PR DESCRIPTION
# Description

Adds a converter for the new Slash Command argument type, attachment. Also includes the ability to refer to arguments in text messages when invoked from text commands.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~ A docs rewrite is in progress and will be  released with 4.0
- [ ] I have added tests that prove my fix is effective or that my feature works
