### PR TITLE
Implement channel types for channel converters

### DIFF
--- a/lib/nyxx_commands.dart
+++ b/lib/nyxx_commands.dart
@@ -36,6 +36,7 @@ export 'src/converters/converter.dart'
         CombineConverter,
         Converter,
         FallbackConverter,
+        GuildChannelConverter,
         attachmentConverter,
         boolConverter,
         categoryGuildChannelConverter,

--- a/lib/src/commands/chat_command.dart
+++ b/lib/src/commands/chat_command.dart
@@ -657,13 +657,17 @@ class ChatCommand
 
         choices ??= argumentConverter?.choices;
 
-        options.add(CommandOptionBuilder(
+        CommandOptionBuilder builder = CommandOptionBuilder(
           argumentConverter?.type ?? CommandOptionType.string,
           name,
           _mappedDescriptions[name]!.value,
           required: !mirror.isOptional,
           choices: choices?.toList(),
-        ));
+        );
+
+        argumentConverter?.processOptionCallback?.call(builder);
+
+        options.add(builder);
       }
 
       return options;

--- a/lib/src/converters/converter.dart
+++ b/lib/src/converters/converter.dart
@@ -124,8 +124,11 @@ class CombineConverter<R, T> implements Converter<T> {
   @override
   final Type output;
 
+  final void Function(CommandOptionBuilder)? _customProcessOptionCallback;
+
   @override
-  final void Function(CommandOptionBuilder)? processOptionCallback;
+  void Function(CommandOptionBuilder)? get processOptionCallback =>
+      _customProcessOptionCallback ?? converter.processOptionCallback;
 
   final Iterable<ArgChoiceBuilder>? _choices;
   final CommandOptionType? _type;
@@ -136,10 +139,11 @@ class CombineConverter<R, T> implements Converter<T> {
     this.process, {
     Iterable<ArgChoiceBuilder>? choices,
     CommandOptionType? type,
-    this.processOptionCallback,
+    void Function(CommandOptionBuilder)? processOptionCallback,
   })  : _choices = choices,
         _type = type,
-        output = T;
+        output = T,
+        _customProcessOptionCallback = processOptionCallback;
 
   @override
   Iterable<ArgChoiceBuilder>? get choices => _choices ?? converter.choices;

--- a/lib/src/converters/converter.dart
+++ b/lib/src/converters/converter.dart
@@ -521,12 +521,10 @@ const Converter<IUser> userConverter = FallbackConverter<IUser>(
   type: CommandOptionType.user,
 );
 
-T? snowflakeToGuildChannel<T extends IGuildChannel>(Snowflake snowflake, IChatContext context) {
+IGuildChannel? snowflakeToGuildChannel(Snowflake snowflake, IChatContext context) {
   if (context.guild != null) {
     try {
-      return context.guild!.channels
-          .whereType<T>()
-          .firstWhere((channel) => channel.id == snowflake);
+      return context.guild!.channels.firstWhere((channel) => channel.id == snowflake);
     } on StateError {
       return null;
     }
@@ -535,15 +533,14 @@ T? snowflakeToGuildChannel<T extends IGuildChannel>(Snowflake snowflake, IChatCo
   return null;
 }
 
-T? convertGuildChannel<T extends IGuildChannel>(StringView view, IChatContext context) {
+IGuildChannel? convertGuildChannel(StringView view, IChatContext context) {
   if (context.guild != null) {
     String word = view.getQuotedWord();
-    Iterable<T> channels = context.guild!.channels.whereType<T>();
 
-    List<T> caseInsensitive = [];
-    List<T> partial = [];
+    List<IGuildChannel> caseInsensitive = [];
+    List<IGuildChannel> partial = [];
 
-    for (final channel in channels) {
+    for (final channel in context.guild!.channels) {
       if (channel.name.toLowerCase() == word.toLowerCase()) {
         caseInsensitive.add(channel);
       }
@@ -562,50 +559,90 @@ T? convertGuildChannel<T extends IGuildChannel>(StringView view, IChatContext co
   return null;
 }
 
+/// A converter that converts input to one or more types of [IGuildChannel]s.
+///
+/// This converter will only allow users to select channels of one of the types in [channelTypes],
+/// and then will further only accept channels of type `T`.
+///
+/// You might also be interested in:
+/// - [guildChannelConverter], a converter for all [IGuildChannel]s;
+/// - [textGuildChannelConverter], a converter for [ITextGuildChannel]s;
+/// - [voiceGuildChannelConverter], a converter for [IVoiceGuildChannel]s;
+/// - [categoryGuildChannelConverter], a converter for [ICategoryGuildChannel]s;
+/// - [stageVoiceChannelConverter], a converter for [IStageVoiceGuildChannel]s.
+class GuildChannelConverter<T extends IGuildChannel> implements Converter<T> {
+  /// The types of channels this converter allows users to select.
+  ///
+  /// If this is `null`, all channel types can be selected. Note that only channels which match both
+  /// these types *and* `T` will be parsed by this converter.
+  final List<ChannelType>? channelTypes;
+
+  final FallbackConverter<IGuildChannel> _internal = const FallbackConverter(
+    [
+      CombineConverter<Snowflake, IGuildChannel>(snowflakeConverter, snowflakeToGuildChannel),
+      Converter<IGuildChannel>(convertGuildChannel),
+    ],
+    type: CommandOptionType.channel,
+  );
+
+  /// Create a new [GuildChannelConverter].
+  const GuildChannelConverter(this.channelTypes);
+
+  @override
+  Iterable<ArgChoiceBuilder> get choices => [];
+
+  @override
+  FutureOr<T?> Function(StringView, IChatContext) get convert => (view, context) async {
+        IGuildChannel? channel = await _internal.convert(view, context);
+
+        if (channel is T) {
+          return channel;
+        }
+
+        return null;
+      };
+
+  @override
+  void Function(CommandOptionBuilder) get processOptionCallback =>
+      (builder) => builder.channelTypes = channelTypes;
+
+  @override
+  Type get output => T;
+
+  @override
+  CommandOptionType get type => CommandOptionType.channel;
+}
+
 /// A converter that converts input to an [IGuildChannel].
 ///
 /// This will first attempt to parse the input as a [Snowflake] that will then be converted to an
 /// [IGuildChannel]. If this fails, the channel will be looked up by name in the current guild.
 ///
-/// This converter has a Discord Slash Command argument type of [CommandOptionType.channel].
-const Converter<IGuildChannel> guildChannelConverter = FallbackConverter(
-  [
-    CombineConverter<Snowflake, IGuildChannel>(
-        snowflakeConverter, snowflakeToGuildChannel<IGuildChannel>),
-    Converter<IGuildChannel>(convertGuildChannel<IGuildChannel>),
-  ],
-  type: CommandOptionType.channel,
-);
+/// This converter has a Discord Slash Command argument type of [CommandOptionType.channel] and is
+/// set to accept all channel types.
+const GuildChannelConverter<IGuildChannel> guildChannelConverter = GuildChannelConverter(null);
 
 /// A converter that converts input to an [ITextGuildChannel].
 ///
 /// This will first attempt to parse the input as a [Snowflake] that will then be converted to an
 /// [ITextGuildChannel]. If this fails, the channel will be looked up by name in the current guild.
 ///
-/// This converter has a Discord Slash Command argument type of [CommandOptionType.channel].
-const Converter<ITextGuildChannel> textGuildChannelConverter = FallbackConverter(
-  [
-    CombineConverter<Snowflake, ITextGuildChannel>(
-        snowflakeConverter, snowflakeToGuildChannel<ITextGuildChannel>),
-    Converter<ITextGuildChannel>(convertGuildChannel<ITextGuildChannel>),
-  ],
-  type: CommandOptionType.channel,
-);
+/// This converter has a Discord Slash Command argument type of [CommandOptionType.channel] and is
+/// set to accept channels of type [ChannelType.text].
+const GuildChannelConverter<ITextGuildChannel> textGuildChannelConverter = GuildChannelConverter([
+  ChannelType.text,
+]);
 
 /// A converter that converts input to an [IVoiceGuildChannel].
 ///
 /// This will first attempt to parse the input as a [Snowflake] that will then be converted to an
 /// [IVoiceGuildChannel]. If this fails, the channel will be looked up by name in the current guild.
 ///
-/// This converter has a Discord Slash Command argument type of [CommandOptionType.channel].
-const Converter<IVoiceGuildChannel> voiceGuildChannelConverter = FallbackConverter(
-  [
-    CombineConverter<Snowflake, IVoiceGuildChannel>(
-        snowflakeConverter, snowflakeToGuildChannel<IVoiceGuildChannel>),
-    Converter<IVoiceGuildChannel>(convertGuildChannel<IVoiceGuildChannel>),
-  ],
-  type: CommandOptionType.channel,
-);
+/// This converter has a Discord Slash Command argument type of [CommandOptionType.channel] and is
+/// set to accept channels of type [ChannelType.voice].
+const GuildChannelConverter<IVoiceGuildChannel> voiceGuildChannelConverter = GuildChannelConverter([
+  ChannelType.voice,
+]);
 
 /// A converter that converts input to an [ICategoryGuildChannel].
 ///
@@ -613,15 +650,12 @@ const Converter<IVoiceGuildChannel> voiceGuildChannelConverter = FallbackConvert
 /// [ICategoryGuildChannel]. If this fails, the channel will be looked up by name in the current
 /// guild.
 ///
-/// This converter has a Discord Slash Command argument type of [CommandOptionType.channel].
-const Converter<ICategoryGuildChannel> categoryGuildChannelConverter = FallbackConverter(
-  [
-    CombineConverter<Snowflake, ICategoryGuildChannel>(
-        snowflakeConverter, snowflakeToGuildChannel<ICategoryGuildChannel>),
-    Converter<ICategoryGuildChannel>(convertGuildChannel<ICategoryGuildChannel>),
-  ],
-  type: CommandOptionType.channel,
-);
+/// This converter has a Discord Slash Command argument type of [CommandOptionType.channel] and it
+/// set to accept channels of type [ChannelType.category].
+const GuildChannelConverter<ICategoryGuildChannel> categoryGuildChannelConverter =
+    GuildChannelConverter([
+  ChannelType.category,
+]);
 
 /// A converter that converts input to an [IStageVoiceGuildChannel].
 ///
@@ -629,15 +663,12 @@ const Converter<ICategoryGuildChannel> categoryGuildChannelConverter = FallbackC
 /// [IStageVoiceGuildChannel]. If this fails, the channel will be looked up by name in the current
 /// guild.
 ///
-/// This converter has a Discord Slash Command argument type of [CommandOptionType.channel].
-const Converter<IStageVoiceGuildChannel> stageVoiceChannelConverter = FallbackConverter(
-  [
-    CombineConverter<Snowflake, IStageVoiceGuildChannel>(
-        snowflakeConverter, snowflakeToGuildChannel<IStageVoiceGuildChannel>),
-    Converter<IStageVoiceGuildChannel>(convertGuildChannel<IStageVoiceGuildChannel>),
-  ],
-  type: CommandOptionType.channel,
-);
+/// This converter has a Discord Slash Command argument type of [CommandOptionType.channel] and is
+/// set to accept channels of type [ChannelType.guildStage].
+const GuildChannelConverter<IStageVoiceGuildChannel> stageVoiceChannelConverter =
+    GuildChannelConverter([
+  ChannelType.guildStage,
+]);
 
 FutureOr<IRole?> snowflakeToRole(Snowflake snowflake, IChatContext context) {
   if (context.guild != null) {
@@ -835,6 +866,7 @@ void registerDefaultConverters(CommandsPlugin commands) {
     ..addConverter(guildChannelConverter)
     ..addConverter(textGuildChannelConverter)
     ..addConverter(voiceGuildChannelConverter)
+    ..addConverter(categoryGuildChannelConverter)
     ..addConverter(stageVoiceChannelConverter)
     ..addConverter(roleConverter)
     ..addConverter(mentionableConverter)

--- a/lib/src/converters/converter.dart
+++ b/lib/src/converters/converter.dart
@@ -83,6 +83,11 @@ class Converter<T> {
   /// Used by [CommandsPlugin.getConverter] to construct assembled converters.
   final Type output;
 
+  /// A callback called with the [CommandOptionBuilder] created for an option using this converter.
+  ///
+  /// Can be used to make custom changes to the builder that are not implemented by default.
+  final void Function(CommandOptionBuilder)? processOptionCallback;
+
   /// Create a new converter.
   ///
   /// Strongly typing converter variables is recommended (i.e use `Converter<String>(...)` instead
@@ -90,6 +95,7 @@ class Converter<T> {
   const Converter(
     this.convert, {
     this.choices,
+    this.processOptionCallback,
     this.type = CommandOptionType.string,
   }) : output = T;
 
@@ -118,6 +124,9 @@ class CombineConverter<R, T> implements Converter<T> {
   @override
   final Type output;
 
+  @override
+  final void Function(CommandOptionBuilder)? processOptionCallback;
+
   final Iterable<ArgChoiceBuilder>? _choices;
   final CommandOptionType? _type;
 
@@ -127,6 +136,7 @@ class CombineConverter<R, T> implements Converter<T> {
     this.process, {
     Iterable<ArgChoiceBuilder>? choices,
     CommandOptionType? type,
+    this.processOptionCallback,
   })  : _choices = choices,
         _type = type,
         output = T;
@@ -165,6 +175,9 @@ class FallbackConverter<T> implements Converter<T> {
   /// The converters this [FallbackConverter] will attempt to use.
   final Iterable<Converter<T>> converters;
 
+  @override
+  final void Function(CommandOptionBuilder)? processOptionCallback;
+
   final Iterable<ArgChoiceBuilder>? _choices;
   final CommandOptionType? _type;
 
@@ -176,6 +189,7 @@ class FallbackConverter<T> implements Converter<T> {
     this.converters, {
     Iterable<ArgChoiceBuilder>? choices,
     CommandOptionType? type,
+    this.processOptionCallback,
   })  : _choices = choices,
         _type = type,
         output = T;


### PR DESCRIPTION
# Description

Adds the ability to modify command option builders after they are created from converters, allowing channel converters to provide a better experience for the end user, displaying only channels that can be selected for the option.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
