### PR TITLE
Implement default command types

### DIFF
--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -512,7 +512,7 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
 
     for (final command in children) {
       if (command is IChatCommandComponent) {
-        if (command is ChatCommand && command.type == CommandType.textOnly) {
+        if (command is ChatCommand && command.resolvedType == CommandType.textOnly) {
           continue;
         }
 
@@ -836,7 +836,7 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
     if (_chatCommands.containsKey(name)) {
       IChatCommandComponent child = _chatCommands[name]!;
 
-      if (child is ChatCommand && child.type != CommandType.slashOnly) {
+      if (child is ChatCommand && child.resolvedType != CommandType.slashOnly) {
         ChatCommand? found = child.getCommand(view);
 
         if (found == null) {

--- a/lib/src/commands/options.dart
+++ b/lib/src/commands/options.dart
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+import 'package:nyxx_commands/src/commands/chat_command.dart';
+
 /// Options that modify how a command behaves.
 ///
 /// You might also be interested in:
@@ -60,6 +62,9 @@ class CommandOptions {
   /// - [IInteractionContext.respond], which can override this setting by setting the `hidden` flag.
   final bool? hideOriginalResponse;
 
+  /// The default [CommandType] for [ChatCommand]s that are children of this entity.
+  final CommandType? defaultCommandType;
+
   /// Create a set of command options.
   ///
   /// Options set to `null` will be inherited from the parent.
@@ -68,5 +73,6 @@ class CommandOptions {
     this.acceptBotCommands,
     this.acceptSelfCommands,
     this.hideOriginalResponse,
+    this.defaultCommandType,
   });
 }

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -14,6 +14,7 @@
 
 import 'package:nyxx_interactions/nyxx_interactions.dart';
 
+import 'commands/chat_command.dart';
 import 'commands/options.dart';
 
 /// Options that modify how the [CommandsPlugin] instance works.
@@ -49,6 +50,9 @@ class CommandsOptions implements CommandOptions {
   @override
   final bool hideOriginalResponse;
 
+  @override
+  final CommandType defaultCommandType;
+
   /// Create a new set of [CommandsOptions].
   const CommandsOptions({
     this.logErrors = true,
@@ -57,5 +61,6 @@ class CommandsOptions implements CommandOptions {
     this.acceptSelfCommands = false,
     this.backend,
     this.hideOriginalResponse = true,
+    this.defaultCommandType = CommandType.all,
   });
 }

--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 import '../checks/checks.dart';
+import '../commands/chat_command.dart';
 import '../commands/interfaces.dart';
 import '../commands/options.dart';
 import '../context/context.dart';
@@ -64,12 +65,18 @@ mixin OptionsMixin<T extends IContext> on ICommandRegisterable<T> implements IOp
         ? (parent as ICommandRegisterable).resolvedOptions
         : parent!.options;
 
+    CommandType? defaultCommandType;
+    if (options.defaultCommandType != CommandType.def) {
+      defaultCommandType = options.defaultCommandType;
+    }
+
     return CommandOptions(
       autoAcknowledgeInteractions:
           options.autoAcknowledgeInteractions ?? parentOptions.autoAcknowledgeInteractions,
       acceptBotCommands: options.acceptBotCommands ?? parentOptions.acceptBotCommands,
       acceptSelfCommands: options.acceptSelfCommands ?? parentOptions.acceptSelfCommands,
       hideOriginalResponse: options.hideOriginalResponse ?? parentOptions.hideOriginalResponse,
+      defaultCommandType: defaultCommandType ?? parentOptions.defaultCommandType,
     );
   }
 }


### PR DESCRIPTION
# Description

Implements default command types to allow for inherited command types. Allows users to entirely enable or disable certain types of chat commands.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
