### PR TITLE
Implement minimum and maximum values for number converters

### DIFF
--- a/lib/nyxx_commands.dart
+++ b/lib/nyxx_commands.dart
@@ -36,8 +36,11 @@ export 'src/converters/converter.dart'
     show
         CombineConverter,
         Converter,
+        DoubleConverter,
         FallbackConverter,
         GuildChannelConverter,
+        IntConverter,
+        NumConverter,
         attachmentConverter,
         boolConverter,
         categoryGuildChannelConverter,

--- a/lib/src/converters/converter.dart
+++ b/lib/src/converters/converter.dart
@@ -317,6 +317,10 @@ int? convertInt(StringView view, IChatContext context) => int.tryParse(view.getQ
 /// A converter that converts input to various types of numbers, possibly with a minimum or maximum
 /// value.
 ///
+/// Note: this converter does not ensure that all values will be in the range `min..max`. [min] and
+/// [max] offer purely client-side validation and input from text commands is not validated beyond
+/// being a valid number.
+///
 /// You might also be interested in:
 /// - [IntConverter], for converting [int]s;
 /// - [DoubleConverter], for converting [double]s.
@@ -344,6 +348,10 @@ class NumConverter<T extends num> extends Converter<T> {
 
 /// A converter that converts input to [int]s, possibly with a minimum or maximum value.
 ///
+/// Note: this converter does not ensure that all values will be in the range `min..max`. [min] and
+/// [max] offer purely client-side validation and input from text commands is not validated beyond
+/// being a valid integer.
+///
 /// You might also be interested in:
 /// - [intConverter], the default [IntConverter].
 class IntConverter extends NumConverter<int> {
@@ -370,6 +378,10 @@ double? convertDouble(StringView view, IChatContext context) =>
     double.tryParse(view.getQuotedWord());
 
 /// A converter that converts input to [double]s, possibly with a minimum or maximum value.
+///
+/// Note: this converter does not ensure that all values will be in the range `min..max`. [min] and
+/// [max] offer purely client-side validation and input from text commands is not validated beyond
+/// being a valid double.
 ///
 /// You might also be interested in:
 /// - [doubleConverter], the default [DoubleConverter].
@@ -647,6 +659,11 @@ IGuildChannel? convertGuildChannel(StringView view, IChatContext context) {
 ///
 /// This converter will only allow users to select channels of one of the types in [channelTypes],
 /// and then will further only accept channels of type `T`.
+///
+///
+/// Note: this converter does not ensure that all values will conform to [channelTypes].
+/// [channelTypes] offers purely client-side validation and input from text commands will not be
+/// validated beyond being assignable to `T`.
 ///
 /// You might also be interested in:
 /// - [guildChannelConverter], a converter for all [IGuildChannel]s;

--- a/lib/src/converters/converter.dart
+++ b/lib/src/converters/converter.dart
@@ -314,18 +314,77 @@ const Converter<String> stringConverter = Converter<String>(
 
 int? convertInt(StringView view, IChatContext context) => int.tryParse(view.getQuotedWord());
 
+/// A converter that converts input to various types of numbers, possibly with a minimum or maximum
+/// value.
+///
+/// You might also be interested in:
+/// - [IntConverter], for converting [int]s;
+/// - [DoubleConverter], for converting [double]s.
+class NumConverter<T extends num> extends Converter<T> {
+  /// The smallest value the user will be allowed to input in the Discord Client.
+  final T? min;
+
+  /// The biggest value the user will be allows to input in the Discord Client.
+  final T? max;
+
+  /// Create a new [NumConverter].
+  const NumConverter(
+    T? Function(StringView, IChatContext) convert, {
+    required CommandOptionType type,
+    this.min,
+    this.max,
+  }) : super(convert, type: type);
+
+  @override
+  void Function(CommandOptionBuilder)? get processOptionCallback => (builder) {
+        builder.min = min;
+        builder.max = max;
+      };
+}
+
+/// A converter that converts input to [int]s, possibly with a minimum or maximum value.
+///
+/// You might also be interested in:
+/// - [intConverter], the default [IntConverter].
+class IntConverter extends NumConverter<int> {
+  /// Create a new [IntConverter].
+  const IntConverter({
+    int? min,
+    int? max,
+  }) : super(
+          convertInt,
+          type: CommandOptionType.integer,
+          min: min,
+          max: max,
+        );
+}
+
 /// A [Converter] that converts input to an [int].
 ///
 /// This converter attempts to parse the next word or quoted section of the input with [int.parse].
 ///
 /// This converter has a Discord Slash Command Argument Type of [CommandOptionType.integer].
-const Converter<int> intConverter = Converter<int>(
-  convertInt,
-  type: CommandOptionType.integer,
-);
+const Converter<int> intConverter = IntConverter();
 
 double? convertDouble(StringView view, IChatContext context) =>
     double.tryParse(view.getQuotedWord());
+
+/// A converter that converts input to [double]s, possibly with a minimum or maximum value.
+///
+/// You might also be interested in:
+/// - [doubleConverter], the default [DoubleConverter].
+class DoubleConverter extends NumConverter<double> {
+  /// Create a new [DoubleConverter].
+  const DoubleConverter({
+    double? min,
+    double? max,
+  }) : super(
+          convertDouble,
+          type: CommandOptionType.integer,
+          min: min,
+          max: max,
+        );
+}
 
 /// A [Converter] that converts input to a [double].
 ///
@@ -333,10 +392,7 @@ double? convertDouble(StringView view, IChatContext context) =>
 /// [double.parse].
 ///
 /// This converter has a Discord Slash Command Argument Type of [CommandOptionType.number].
-const Converter<double> doubleConverter = Converter<double>(
-  convertDouble,
-  type: CommandOptionType.number,
-);
+const Converter<double> doubleConverter = DoubleConverter();
 
 bool? convertBool(StringView view, IChatContext context) {
   String word = view.getQuotedWord();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   logging: ^1.0.2
   meta: ^1.7.0
   nyxx: ^3.0.0
-  nyxx_interactions: ^4.0.0
+  nyxx_interactions: ^4.1.0
   random_string: ^2.3.1
 
 dev_dependencies:


### PR DESCRIPTION
# Description

Adds the ability to specify and minimum and maximum value for number converters.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
