### PR TITLE
Fix slash commands nested in text-only commands not being registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.2
+__Bug fixes__:
+- Fixes an issue where slash commands nested within text-only commands would not be registered
+
 ## 4.1.1
 __Bug fixes__:
 - Correctly export the `@AUtocomplete(...)` annotation.

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -511,9 +511,7 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
     const Snowflake zeroSnowflake = Snowflake.zero();
 
     for (final command in children) {
-      if (command is IChatCommandComponent &&
-          !command.hasSlashCommand &&
-          (command is! ChatCommand || command.resolvedType == CommandType.textOnly)) {
+      if (!_shouldGnerateBuildersFor(command)) {
         continue;
       }
 
@@ -602,6 +600,18 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
     }
 
     return builders;
+  }
+
+  bool _shouldGnerateBuildersFor(ICommandRegisterable<IContext> child) {
+    if (child is IChatCommandComponent) {
+      if (child.hasSlashCommand) {
+        return true;
+      }
+
+      return child is ChatCommand && child.type != CommandType.textOnly;
+    }
+
+    return true;
   }
 
   Future<Iterable<CommandPermissionBuilderAbstract>> _getPermissions(IChecked command) async {

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -557,7 +557,7 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
             type: SlashCommandType.chat,
           );
 
-          if (command is ChatCommand) {
+          if (command is ChatCommand && command.resolvedType != CommandType.textOnly) {
             builder.registerHandler((interaction) => _processChatInteraction(interaction, command));
 
             _processAutocompleteHandlerRegistration(builder.options, command);

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -511,14 +511,10 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
     const Snowflake zeroSnowflake = Snowflake.zero();
 
     for (final command in children) {
-      if (command is IChatCommandComponent) {
-        if (command is ChatCommand && command.resolvedType == CommandType.textOnly) {
-          continue;
-        }
-
-        if (!command.hasSlashCommand && command is! ChatCommand) {
-          continue;
-        }
+      if (command is IChatCommandComponent &&
+          !command.hasSlashCommand &&
+          (command is! ChatCommand || command.resolvedType == CommandType.textOnly)) {
+        continue;
       }
 
       Iterable<CommandPermissionBuilderAbstract> permissions = await _getPermissions(command);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx_commands
-version: 4.1.1
+version: 4.1.2
 description: A framework for easily creating slash commands and text commands for Discord using the nyxx library.
 
 homepage: https://github.com/nyxx-discord/nyxx_commands/blob/main/README.md


### PR DESCRIPTION
# Description

Fixes an issue where slash commands nested within top-level text-only commands would be skipped during the registration phase.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
