### PR TITLE
Add basic methods to AutocompleteContext allowing access to other arguments

### DIFF
--- a/lib/src/context/autocomplete_context.dart
+++ b/lib/src/context/autocomplete_context.dart
@@ -75,4 +75,36 @@ class AutocompleteContext implements IContextBase, IInteractionContextBase {
     required this.option,
     required this.currentValue,
   });
+
+  /// A map containing the arguments and the values that the user has inputted so far.
+  ///
+  /// The keys of this map depend on the names of the arguments set in [command]. If a user has not
+  /// yet filled in an argument, it will not be present in this map.
+  ///
+  /// The values might contain partial data.
+  late final Map<String, String> existingArguments = Map.fromEntries(
+    interactionEvent.options.map((option) => MapEntry(option.name, option.value.toString())),
+  );
+
+  /// A map containing the arguments of [command] and their value, if the user has inputted a value
+  /// for them.
+  ///
+  /// The keys of this map depend on the names of the arguments set in [command].
+  ///
+  /// The values might contain partial data.
+  late final Map<String, String?> arguments = (() {
+    ISlashCommand command = commands.interactions.commands.singleWhere(
+      (command) => command.id == interaction.commandId,
+    );
+
+    Map<String, String?> result = Map.fromIterable(
+      command.options.map((option) => option.name),
+      value: (option) => existingArguments[option],
+    );
+
+    return result;
+  })();
+
+  /// Whether the user has inputted a value for an argument with the name [name].
+  bool hasArgument(String name) => existingArguments.containsKey(name);
 }

--- a/lib/src/context/autocomplete_context.dart
+++ b/lib/src/context/autocomplete_context.dart
@@ -61,21 +61,6 @@ class AutocompleteContext implements IContextBase, IInteractionContextBase {
   /// for more.
   final String currentValue;
 
-  /// Create a new [AutocompleteContext].
-  AutocompleteContext({
-    required this.commands,
-    required this.guild,
-    required this.channel,
-    required this.member,
-    required this.user,
-    required this.command,
-    required this.client,
-    required this.interaction,
-    required this.interactionEvent,
-    required this.option,
-    required this.currentValue,
-  });
-
   /// A map containing the arguments and the values that the user has inputted so far.
   ///
   /// The keys of this map depend on the names of the arguments set in [command]. If a user has not
@@ -92,18 +77,31 @@ class AutocompleteContext implements IContextBase, IInteractionContextBase {
   /// The keys of this map depend on the names of the arguments set in [command].
   ///
   /// The values might contain partial data.
-  late final Map<String, String?> arguments = (() {
+  late final Map<String, String?> arguments;
+
+  /// Create a new [AutocompleteContext].
+  AutocompleteContext({
+    required this.commands,
+    required this.guild,
+    required this.channel,
+    required this.member,
+    required this.user,
+    required this.command,
+    required this.client,
+    required this.interaction,
+    required this.interactionEvent,
+    required this.option,
+    required this.currentValue,
+  }) {
     ISlashCommand command = commands.interactions.commands.singleWhere(
       (command) => command.id == interaction.commandId,
     );
 
-    Map<String, String?> result = Map.fromIterable(
+    arguments = Map.fromIterable(
       command.options.map((option) => option.name),
       value: (option) => existingArguments[option],
     );
-
-    return result;
-  })();
+  }
 
   /// Whether the user has inputted a value for an argument with the name [name].
   bool hasArgument(String name) => existingArguments.containsKey(name);


### PR DESCRIPTION
# Description

Adds methods to `AutocompleteContext` which simplify the process of obtaining the values of other arguments the user might have already filled in.

Partially implements #52.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
