### PR TITLE
Bump nyxx & nyxx_interactions to their latest versions

### DIFF
--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -215,6 +215,13 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
     }
   }
 
+  @override
+  void onBotStop(INyxx nyxx, Logger logger) {
+    _onPostCallController.close();
+    _onPreCallController.close();
+    _onCommandErrorController.close();
+  }
+
   Future<void> _syncWithInteractions() async {
     for (final builder in await _getSlashBuilders()) {
       interactions.registerSlashCommand(builder);

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -216,10 +216,10 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
   }
 
   @override
-  void onBotStop(INyxx nyxx, Logger logger) {
-    _onPostCallController.close();
-    _onPreCallController.close();
-    _onCommandErrorController.close();
+  Future<void> onBotStop(INyxx nyxx, Logger logger) async {
+    await _onPostCallController.close();
+    await _onPreCallController.close();
+    await _onCommandErrorController.close();
   }
 
   Future<void> _syncWithInteractions() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   dart_style: ^2.2.1
   logging: ^1.0.2
   meta: ^1.7.0
-  nyxx: ^3.0.0
-  nyxx_interactions: ^4.2.1
+  nyxx: ^4.0.0
+  nyxx_interactions: ^4.3.0
   random_string: ^2.3.1
   path: ^1.8.1
 


### PR DESCRIPTION
# Description

Bump nyxx & nyxx_interactions to their latest versions. Add clean disposal of CommandsPlugin to fall in line with the overal clean disposal introduced in nyxx 4.0.0.

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
