### PR TITLE
Move command type to command options

### DIFF
--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -554,7 +554,7 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
             localizationsDescription: command.localizedDescriptions,
           );
 
-          if (command is ChatCommand && command.resolvedType != CommandType.textOnly) {
+          if (command is ChatCommand && command.resolvedOptions.type != CommandType.textOnly) {
             builder.registerHandler((interaction) => _processChatInteraction(interaction, command));
 
             _processAutocompleteHandlerRegistration(builder.options, command);
@@ -605,7 +605,7 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
         return true;
       }
 
-      return child is ChatCommand && child.type != CommandType.textOnly;
+      return child is ChatCommand && child.resolvedOptions.type != CommandType.textOnly;
     }
 
     return true;
@@ -788,7 +788,7 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
     if (_chatCommands.containsKey(name)) {
       IChatCommandComponent child = _chatCommands[name]!;
 
-      if (child is ChatCommand && child.resolvedType != CommandType.slashOnly) {
+      if (child is ChatCommand && child.resolvedOptions.type != CommandType.slashOnly) {
         ChatCommand? found = child.getCommand(view);
 
         if (found == null) {

--- a/lib/src/commands/chat_command.dart
+++ b/lib/src/commands/chat_command.dart
@@ -358,11 +358,16 @@ class ChatCommand
       throw CommandRegistrationError('Invalid localized name for command "$name".');
     }
 
-    Type contextType = IChatContext;
-    if (resolvedOptions.type == CommandType.slashOnly) {
-      contextType = InteractionChatContext;
-    } else {
-      contextType = MessageChatContext;
+    Type contextType;
+    switch (resolvedOptions.type) {
+      case CommandType.textOnly:
+        contextType = MessageChatContext;
+        break;
+      case CommandType.slashOnly:
+        contextType = InteractionChatContext;
+        break;
+      default:
+        contextType = IChatContext;
     }
 
     _loadArguments(execute, contextType);

--- a/lib/src/commands/chat_command.dart
+++ b/lib/src/commands/chat_command.dart
@@ -337,83 +337,9 @@ class ChatCommand
   /// - [ChatCommand.slashOnly], for creating [ChatCommand]s with type [CommandType.slashOnly];
   /// - [ChatCommand.textOnly], for creating [ChatCommand]s with type [CommandType.textOnly].
   ChatCommand(
-    String name,
-    String description,
-    Function execute, {
-    List<String> aliases = const [],
-    Iterable<IChatCommandComponent> children = const [],
-    Iterable<AbstractCheck> checks = const [],
-    Iterable<AbstractCheck> singleChecks = const [],
-    CommandOptions options = const CommandOptions(),
-    Map<Locale, String>? localizedNames,
-    Map<Locale, String>? localizedDescriptions,
-  }) : this._(
-          name,
-          description,
-          execute,
-          IChatContext,
-          aliases: aliases,
-          children: children,
-          checks: checks,
-          singleChecks: singleChecks,
-          options: options,
-          localizedNames: localizedNames,
-          localizedDescriptions: localizedDescriptions,
-        );
-
-  /// Create a new [ChatCommand] with type [CommandType.textOnly].
-  ChatCommand.textOnly(
-    String name,
-    String description,
-    Function execute, {
-    List<String> aliases = const [],
-    Iterable<IChatCommandComponent> children = const [],
-    Iterable<AbstractCheck> checks = const [],
-    Iterable<AbstractCheck> singleChecks = const [],
-    CommandOptions options = const CommandOptions(),
-  }) : this._(
-          name,
-          description,
-          execute,
-          MessageChatContext,
-          aliases: aliases,
-          children: children,
-          checks: checks,
-          singleChecks: singleChecks,
-          options: options,
-        );
-
-  /// Create a new [ChatCommand] with type [CommandType.slashOnly].
-  ChatCommand.slashOnly(
-    String name,
-    String description,
-    Function execute, {
-    List<String> aliases = const [],
-    Iterable<IChatCommandComponent> children = const [],
-    Iterable<AbstractCheck> checks = const [],
-    Iterable<AbstractCheck> singleChecks = const [],
-    CommandOptions options = const CommandOptions(),
-    Map<Locale, String>? localizedNames,
-    Map<Locale, String>? localizedDescriptions,
-  }) : this._(
-          name,
-          description,
-          execute,
-          InteractionChatContext,
-          aliases: aliases,
-          children: children,
-          checks: checks,
-          singleChecks: singleChecks,
-          options: options,
-          localizedNames: localizedNames,
-          localizedDescriptions: localizedDescriptions,
-        );
-
-  ChatCommand._(
     this.name,
     this.description,
-    this.execute,
-    Type contextType, {
+    this.execute, {
     this.aliases = const [],
     Iterable<IChatCommandComponent> children = const [],
     Iterable<AbstractCheck> checks = const [],
@@ -430,6 +356,13 @@ class ChatCommand
         localizedNames!.values
             .any((names) => !commandNameRegexp.hasMatch(names) || names != names.toLowerCase()))) {
       throw CommandRegistrationError('Invalid localized name for command "$name".');
+    }
+
+    Type contextType = IChatContext;
+    if (resolvedOptions.type == CommandType.slashOnly) {
+      contextType = InteractionChatContext;
+    } else {
+      contextType = MessageChatContext;
     }
 
     _loadArguments(execute, contextType);

--- a/lib/src/commands/chat_command.dart
+++ b/lib/src/commands/chat_command.dart
@@ -57,14 +57,6 @@ enum CommandType {
 
   /// Indicates that a [ChatCommand] can be executed by both Slash Commands and text messages.
   all,
-
-  /// Indicates that a [ChatCommand] should use the default type provided by [IOptions.options].
-  ///
-  /// If the default type provided by the options is itself [def], the behaviour is identical to
-  /// [all].
-  // TODO: Instead of having [def], make [ChatCommand.type] be a classical option
-  // ([ChatCommand.options.type]) and have it be inherited.
-  def,
 }
 
 mixin ChatGroupMixin implements IChatCommandComponent {
@@ -134,7 +126,7 @@ mixin ChatGroupMixin implements IChatCommandComponent {
     if (_childrenMap.containsKey(name)) {
       IChatCommandComponent child = _childrenMap[name]!;
 
-      if (child is ChatCommand && child.resolvedType != CommandType.slashOnly) {
+      if (child is ChatCommand && child.resolvedOptions.type != CommandType.slashOnly) {
         ChatCommand? found = child.getCommand(view);
 
         if (found == null) {
@@ -160,7 +152,7 @@ mixin ChatGroupMixin implements IChatCommandComponent {
 
   @override
   bool get hasSlashCommand => children.any((child) =>
-      (child is ChatCommand && child.resolvedType != CommandType.textOnly) ||
+      (child is ChatCommand && child.resolvedOptions.type != CommandType.textOnly) ||
       child.hasSlashCommand);
 
   @override
@@ -177,7 +169,7 @@ mixin ChatGroupMixin implements IChatCommandComponent {
           localizationsName: child.localizedNames,
           localizationsDescription: child.localizedDescriptions,
         ));
-      } else if (child is ChatCommand && child.resolvedType != CommandType.textOnly) {
+      } else if (child is ChatCommand && child.resolvedOptions.type != CommandType.textOnly) {
         options.add(CommandOptionBuilder(
           CommandOptionType.subCommand,
           child.name,
@@ -293,32 +285,6 @@ class ChatCommand
   @override
   final String description;
 
-  /// The type of this [ChatCommand].
-  ///
-  /// The type of a [ChatCommand] influences how it can be invoked and can be used to make chat
-  /// commands executable only through Slash Commands, or only through text messages.
-  ///
-  /// You might also be interested in:
-  /// - [resolvedType], for getting the resolved type of this command.
-  /// - [ChatCommand.slashOnly], for creating [ChatCommand]s with type [CommandType.slashOnly];
-  /// - [ChatCommand.textOnly], for creating [ChatCommand]s with type [CommandType.textOnly].
-  final CommandType type;
-
-  /// The resolved type of this [ChatCommand].
-  ///
-  /// If [type] is [CommandType.def], this will query the parent of this command for the default
-  /// type. Otherwise, [type] is returned.
-  ///
-  /// If [type] is [CommandType.def] and no parent provides a default type, [CommandType.def] is
-  /// returned.
-  CommandType get resolvedType {
-    if (type != CommandType.def) {
-      return type;
-    }
-
-    return resolvedOptions.defaultCommandType ?? CommandType.def;
-  }
-
   /// The function called to execute this command.
   ///
   /// The argument types for the function are dynamically loaded, so you should specify the types of
@@ -375,7 +341,6 @@ class ChatCommand
     String description,
     Function execute, {
     List<String> aliases = const [],
-    CommandType type = CommandType.def,
     Iterable<IChatCommandComponent> children = const [],
     Iterable<AbstractCheck> checks = const [],
     Iterable<AbstractCheck> singleChecks = const [],
@@ -388,7 +353,6 @@ class ChatCommand
           execute,
           IChatContext,
           aliases: aliases,
-          type: type,
           children: children,
           checks: checks,
           singleChecks: singleChecks,
@@ -413,7 +377,6 @@ class ChatCommand
           execute,
           MessageChatContext,
           aliases: aliases,
-          type: CommandType.textOnly,
           children: children,
           checks: checks,
           singleChecks: singleChecks,
@@ -438,7 +401,6 @@ class ChatCommand
           execute,
           InteractionChatContext,
           aliases: aliases,
-          type: CommandType.slashOnly,
           children: children,
           checks: checks,
           singleChecks: singleChecks,
@@ -453,7 +415,6 @@ class ChatCommand
     this.execute,
     Type contextType, {
     this.aliases = const [],
-    this.type = CommandType.def,
     Iterable<IChatCommandComponent> children = const [],
     Iterable<AbstractCheck> checks = const [],
     Iterable<AbstractCheck> singleChecks = const [],
@@ -593,7 +554,7 @@ class ChatCommand
 
   @override
   Iterable<CommandOptionBuilder> getOptions(CommandsPlugin commands) {
-    if (resolvedType != CommandType.textOnly) {
+    if (resolvedOptions.type != CommandType.textOnly) {
       List<CommandOptionBuilder> options = [];
 
       for (final parameter in _functionData.parametersData.skip(1)) {
@@ -634,9 +595,9 @@ class ChatCommand
           'All child commands of chat groups or commands must implement IChatCommandComponent');
     }
 
-    if (resolvedType != CommandType.textOnly) {
+    if (resolvedOptions.type != CommandType.textOnly) {
       if (command.hasSlashCommand ||
-          (command is ChatCommand && command.resolvedType != CommandType.textOnly)) {
+          (command is ChatCommand && command.resolvedOptions.type != CommandType.textOnly)) {
         throw CommandRegistrationError('Cannot nest Slash commands!');
       }
     }

--- a/lib/src/commands/options.dart
+++ b/lib/src/commands/options.dart
@@ -62,8 +62,11 @@ class CommandOptions {
   /// - [IInteractionContext.respond], which can override this setting by setting the `hidden` flag.
   final bool? hideOriginalResponse;
 
-  /// The default [CommandType] for [ChatCommand]s that are children of this entity.
-  final CommandType? defaultCommandType;
+  /// The type of [ChatCommand]s that are children of this entity.
+  ///
+  /// The type of a [ChatCommand] influences how it can be invoked and can be used to make chat
+  /// commands executable only through Slash Commands, or only through text messages.
+  final CommandType? type;
 
   /// Create a set of command options.
   ///
@@ -73,6 +76,6 @@ class CommandOptions {
     this.acceptBotCommands,
     this.acceptSelfCommands,
     this.hideOriginalResponse,
-    this.defaultCommandType,
+    this.type,
   });
 }

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -51,7 +51,7 @@ class CommandsOptions implements CommandOptions {
   final bool hideOriginalResponse;
 
   @override
-  final CommandType defaultCommandType;
+  final CommandType type;
 
   /// Create a new set of [CommandsOptions].
   const CommandsOptions({
@@ -61,6 +61,6 @@ class CommandsOptions implements CommandOptions {
     this.acceptSelfCommands = false,
     this.backend,
     this.hideOriginalResponse = true,
-    this.defaultCommandType = CommandType.all,
+    this.type = CommandType.all,
   });
 }

--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -65,18 +65,13 @@ mixin OptionsMixin<T extends IContext> on ICommandRegisterable<T> implements IOp
         ? (parent as ICommandRegisterable).resolvedOptions
         : parent!.options;
 
-    CommandType? defaultCommandType;
-    if (options.defaultCommandType != CommandType.def) {
-      defaultCommandType = options.defaultCommandType;
-    }
-
     return CommandOptions(
       autoAcknowledgeInteractions:
           options.autoAcknowledgeInteractions ?? parentOptions.autoAcknowledgeInteractions,
       acceptBotCommands: options.acceptBotCommands ?? parentOptions.acceptBotCommands,
       acceptSelfCommands: options.acceptSelfCommands ?? parentOptions.acceptSelfCommands,
       hideOriginalResponse: options.hideOriginalResponse ?? parentOptions.hideOriginalResponse,
-      defaultCommandType: defaultCommandType ?? parentOptions.defaultCommandType,
+      type: options.type ?? parentOptions.type,
     );
   }
 }


### PR DESCRIPTION
# Description

Moves `ChatCommand.type` to `CommandOptions.type`, making it an inherited property.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
