### PR TITLE
Allow arbitrary patterns & async functions as a prefix

### DIFF
--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -242,10 +242,10 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
       Pattern prefix = await this.prefix!(message);
       StringView view = StringView(message.content);
 
-      Match? m = view.skipPattern(prefix);
+      Match? matchedPrefix = view.skipPattern(prefix);
 
-      if (m != null) {
-        IChatContext context = await _messageChatContext(message, view, m.group(0)!);
+      if (matchedPrefix != null) {
+        IChatContext context = await _messageChatContext(message, view, matchedPrefix.group(0)!);
 
         if (message.author.bot && !context.command.resolvedOptions.acceptBotCommands!) {
           return;

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -77,7 +77,10 @@ final Logger logger = Logger('Commands');
 class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
   /// A function called to determine the prefix for a specific message.
   ///
-  /// This function should return a [String] representing the prefix to use for a given message.
+  /// This function should return a [Pattern] that should match the start of the message content if
+  /// it begins with the prefix.
+  ///
+  /// If this function is `null`, message commands are disabled.
   ///
   /// For example, for a prefix of `!`:
   /// ```dart
@@ -86,13 +89,14 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
   ///
   /// Or, for either `!` or `$` as a prefix:
   /// ```dart
-  /// (message) => message.content.startsWith('!') ? '!' : '$'
+  /// (_) => RegExp(r'!|\$')
   /// ```
   ///
   /// You might also be interested in:
   /// - [dmOr], which allows for commands in private messages to omit the prefix;
   /// - [mentionOr], which allows for commands to be executed with the client's mention (ping).
-  final String Function(IMessage) prefix;
+  // TODO: Make the default command type be `slashOnly` if prefix is not specified.
+  final FutureOr<Pattern> Function(IMessage)? prefix;
 
   final StreamController<CommandsException> _onCommandErrorController =
       StreamController.broadcast();
@@ -196,7 +200,9 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
     client = nyxx;
 
     if (nyxx is INyxxWebsocket) {
-      nyxx.eventsWs.onMessageReceived.listen((event) => _processMessage(event.message));
+      if (prefix != null) {
+        nyxx.eventsWs.onMessageReceived.listen((event) => _processMessage(event.message));
+      }
 
       interactions = IInteractions.create(options.backend ?? WebsocketInteractionBackend(nyxx));
     } else {
@@ -233,11 +239,13 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<IContext> {
 
   Future<void> _processMessage(IMessage message) async {
     try {
-      String prefix = this.prefix(message);
+      Pattern prefix = await this.prefix!(message);
       StringView view = StringView(message.content);
 
-      if (view.skipString(prefix)) {
-        IChatContext context = await _messageChatContext(message, view, prefix);
+      Match? m = view.skipPattern(prefix);
+
+      if (m != null) {
+        IChatContext context = await _messageChatContext(message, view, m.group(0)!);
 
         if (message.author.bot && !context.command.resolvedOptions.acceptBotCommands!) {
           return;

--- a/lib/src/util/view.dart
+++ b/lib/src/util/view.dart
@@ -110,6 +110,7 @@ class StringView {
   ///
   /// You might also be interested in:
   /// - [skipWhitespace], for skipping arbitrary spans of whitespace.
+  /// - [skipPattern], for testing arbitrary patterns.
   bool skipString(String s) {
     if (index + s.length < end && buffer.substring(index, index + s.length) == s) {
       history.add(index);
@@ -117,6 +118,24 @@ class StringView {
       return true;
     }
     return false;
+  }
+
+  /// Match [p] at the text directly after the cursor and skip over the match if it exists, else
+  /// return `null`.
+  ///
+  /// You might also be interested in:
+  /// - [skipWhitespace], for skipping arbitrary spans of whitespace.
+  /// - [skipString], for skipping arbitrary strings.
+  Match? skipPattern(Pattern p) {
+    Match? m = p.matchAsPrefix(buffer.substring(index));
+
+    if (m != null) {
+      history.add(index);
+      // The end of the match is the same as its length since it was matched as a prefix.
+      index += m.end;
+    }
+
+    return m;
   }
 
   /// Skip to the next non-whitespace character in [buffer].

--- a/lib/src/util/view.dart
+++ b/lib/src/util/view.dart
@@ -127,15 +127,15 @@ class StringView {
   /// - [skipWhitespace], for skipping arbitrary spans of whitespace.
   /// - [skipString], for skipping arbitrary strings.
   Match? skipPattern(Pattern p) {
-    Match? m = p.matchAsPrefix(buffer.substring(index));
+    Match? match = p.matchAsPrefix(buffer.substring(index));
 
-    if (m != null) {
+    if (match != null) {
       history.add(index);
       // The end of the match is the same as its length since it was matched as a prefix.
-      index += m.end;
+      index += match.end;
     }
 
-    return m;
+    return match;
   }
 
   /// Skip to the next non-whitespace character in [buffer].


### PR DESCRIPTION
# Description

Expands the capabilities of `CommandsPlugin.prefix` to allow for complex patterns to be returned and for the function to be asynchronous.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
