### PR TITLE
Add option to control auto-acknowledge timeout

### DIFF
--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -270,12 +270,16 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<ICommandContext
   Future<void> _processInteractionCommand(IInteractionCommandContext context) async {
     try {
       if (context.command.resolvedOptions.autoAcknowledgeInteractions!) {
-        Duration latency = Duration.zero;
-        if (client is INyxxWebsocket) {
-          latency = (client as INyxxWebsocket).shardManager.gatewayLatency;
-        }
+        Duration? timeout = context.command.resolvedOptions.autoAcknowledgeDuration;
 
-        Duration timeout = Duration(seconds: 3) - latency * 2;
+        if (timeout == null) {
+          Duration latency = const Duration(seconds: 1);
+          if (client is INyxxWebsocket) {
+            latency = (client as INyxxWebsocket).shardManager.gatewayLatency;
+          }
+
+          timeout = const Duration(seconds: 3) - latency * 2;
+        }
 
         Timer(timeout, () async {
           try {

--- a/lib/src/commands/options.dart
+++ b/lib/src/commands/options.dart
@@ -31,8 +31,19 @@ class CommandOptions {
   /// Setting this to false means that you must acknowledge the interaction yourself.
   ///
   /// You might also be interested in:
+  /// - [autoAcknowledgeDuration], for setting the time after which interactions will be
+  ///   acknowledged.
   /// - [IInteractionInteractiveContext.acknowledge], for manually acknowledging interactions.
   final bool? autoAcknowledgeInteractions;
+
+  /// The duration after which to automatically acknowledge interactions.
+  ///
+  /// Has no effect if [autoAcknowledgeInteractions] is `false`.
+  ///
+  /// If this is `null`, the timeout for interactions is calculated based on the bot's latency. On
+  /// unstable networks, this might result in some interactions not being acknowledged, in which
+  /// case setting this option might help.
+  final Duration? autoAcknowledgeDuration;
 
   /// Whether to accept messages sent by bot accounts as possible commands.
   ///
@@ -71,6 +82,7 @@ class CommandOptions {
   /// Options set to `null` will be inherited from the parent.
   const CommandOptions({
     this.autoAcknowledgeInteractions,
+    this.autoAcknowledgeDuration,
     this.acceptBotCommands,
     this.acceptSelfCommands,
     this.defaultResponseLevel,

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -61,10 +61,14 @@ class CommandsOptions implements CommandOptions {
   @override
   final CommandType type;
 
+  @override
+  final Duration? autoAcknowledgeDuration;
+
   /// Create a new set of [CommandsOptions].
   const CommandsOptions({
     this.logErrors = true,
     this.autoAcknowledgeInteractions = true,
+    this.autoAcknowledgeDuration,
     this.acceptBotCommands = false,
     this.acceptSelfCommands = false,
     this.backend,

--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -87,6 +87,8 @@ mixin OptionsMixin<T extends ICommandContext> on ICommandRegisterable<T> impleme
       acceptSelfCommands: options.acceptSelfCommands ?? parentOptions.acceptSelfCommands,
       defaultResponseLevel: options.defaultResponseLevel ?? parentOptions.defaultResponseLevel,
       type: options.type ?? parentType,
+      autoAcknowledgeDuration:
+          options.autoAcknowledgeDuration ?? parentOptions.autoAcknowledgeDuration,
     );
   }
 }


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
