### PR TITLE
Don't error when autocompletion returns null

### DIFF
--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -335,9 +335,7 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<ICommandContext
       try {
         Iterable<ArgChoiceBuilder>? choices = await callback(context);
 
-        if (choices != null) {
-          interactionEvent.respond(choices.toList());
-        }
+        interactionEvent.respond(choices?.toList() ?? []);
       } on Exception catch (e) {
         throw AutocompleteFailedException(e, context);
       }


### PR DESCRIPTION
# Description

Changes autocompletion to correctly display "no results" instead of an error in the Discord UI when an autocompletion callback returns `null`, as per the documentation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
