### PR TITLE
Fix types of SimpleConverter members

### DIFF
--- a/lib/src/converters/simple.dart
+++ b/lib/src/converters/simple.dart
@@ -78,7 +78,7 @@ abstract class SimpleConverter<T> implements Converter<T> {
   /// [stringify] must be top-level or static functions. Function literals are not `const`, so they
   /// cannot be used in a constant creation expression.
   const factory SimpleConverter({
-    required Iterable<T> Function(IContextData) provider,
+    required FutureOr<Iterable<T>> Function(IContextData) provider,
     required String Function(T) stringify,
     int sensitivity,
     T? Function(StringView, IContextData) reviver,
@@ -152,7 +152,7 @@ abstract class SimpleConverter<T> implements Converter<T> {
 
 class _DynamicSimpleConverter<T> extends SimpleConverter<T> {
   @override
-  final Iterable<T> Function(IContextData) provider;
+  final FutureOr<Iterable<T>> Function(IContextData) provider;
 
   @override
   final String Function(T) stringify;

--- a/lib/src/converters/simple.dart
+++ b/lib/src/converters/simple.dart
@@ -82,7 +82,7 @@ abstract class SimpleConverter<T> implements Converter<T> {
     required String Function(T) stringify,
     int sensitivity,
     T? Function(StringView, IContextData) reviver,
-  }) = _DynamicSimpleConverter;
+  }) = _DynamicSimpleConverter<T>;
 
   /// Create a new [SimpleConverter] which converts an unchanging number of elements.
   ///
@@ -94,7 +94,7 @@ abstract class SimpleConverter<T> implements Converter<T> {
     required String Function(T) stringify,
     int sensitivity,
     T? Function(StringView, IContextData) reviver,
-  }) = _FixedSimpleConverter;
+  }) = _FixedSimpleConverter<T>;
 
   @override
   Iterable<ArgChoiceBuilder>? Function(AutocompleteContext)? get autocompleteCallback =>


### PR DESCRIPTION
# Description

Fixes the constructors of SimpleConverter so they can actually be used and allows Futures in providers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
