### PR TITLE
Don't return nothing when autocomplete query is empty

### DIFF
--- a/lib/src/converters/simple.dart
+++ b/lib/src/converters/simple.dart
@@ -98,14 +98,22 @@ abstract class SimpleConverter<T> implements Converter<T> {
 
   @override
   Future<Iterable<ArgChoiceBuilder>>? Function(AutocompleteContext)? get autocompleteCallback =>
-      (context) async => fuzzy
-          .extractTop(
-            query: context.currentValue,
-            choices: (await provider(context)).map(stringify).toList(),
-            limit: 25,
-            cutoff: sensitivity,
-          )
-          .map((e) => ArgChoiceBuilder(e.choice, e.choice));
+      (context) async {
+        List<String> choices = (await provider(context)).map(stringify).toList();
+
+        if (context.currentValue.isEmpty) {
+          return choices.take(25).map((e) => ArgChoiceBuilder(e, e));
+        }
+
+        return fuzzy
+            .extractTop(
+              query: context.currentValue,
+              choices: choices,
+              limit: 25,
+              cutoff: sensitivity,
+            )
+            .map((e) => ArgChoiceBuilder(e.choice, e.choice));
+      };
 
   @override
   Future<T?> Function(StringView view, IContextData context) get convert => (view, context) async {


### PR DESCRIPTION
# Description

Previously, if the input to an autocomplete query was empty, the search would return no results in SimpleConverter. This PR changes this to show the top 25 options returned by the provider.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
