### PR TITLE
Correctly update id map when using button components

### DIFF
--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -340,6 +340,8 @@ mixin InteractiveMixin implements IInteractiveContext, IContextData {
       ButtonStyle? style = styles?[value];
       String id = createId();
 
+      idToValue[id] = value;
+
       // We have to copy since the fields on ButtonBuilder are final.
       return ButtonBuilder(
         builder.label,


### PR DESCRIPTION
# Description

Adds a missing line that prevented button values and ids from being tracked in `getButtonSelection`, breaking the method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
