### PR TITLE
Fix miscellaneous bugs

### DIFF
--- a/bin/compile/element_tree_visitor.dart
+++ b/bin/compile/element_tree_visitor.dart
@@ -128,7 +128,7 @@ class EntireAstVisitor extends RecursiveAstVisitor<void> {
   void visitPartDirective(PartDirective directive) {
     super.visitPartDirective(directive);
 
-    DirectiveUri uri = directive.element2!.uri;
+    DirectiveUri uri = directive.element!.uri;
     if (uri is! DirectiveUriWithSource) {
       throw CommandsError('Unknown part target $directive');
     }

--- a/bin/compile/function_metadata/metadata_builder.dart
+++ b/bin/compile/function_metadata/metadata_builder.dart
@@ -77,7 +77,7 @@ Iterable<CompileTimeFunctionData> getFunctionData(
             return false;
           }
 
-          return result.type?.element2?.location?.encoding == source;
+          return result.type?.element?.location?.encoding == source;
         });
       }
 

--- a/bin/compile/to_source.dart
+++ b/bin/compile/to_source.dart
@@ -55,7 +55,7 @@ List<String>? toTypeSource(DartType type, [bool handleTypeParameters = true]) {
       [],
       (previousValue, element) {
         // Only include each type parameter once
-        if (!previousValue.any((t) => t.element2 == element.element2)) {
+        if (!previousValue.any((t) => t.element == element.element)) {
           previousValue.add(element);
         }
 
@@ -68,7 +68,7 @@ List<String>? toTypeSource(DartType type, [bool handleTypeParameters = true]) {
       typeArguments += '<';
 
       for (final typeParameter in typeParameters) {
-        typeArguments += typeParameter.element2.name;
+        typeArguments += typeParameter.element.name;
 
         if (typeParameter.bound is! DynamicType) {
           typeArguments += ' extends ';
@@ -103,20 +103,20 @@ List<String>? toTypeSource(DartType type, [bool handleTypeParameters = true]) {
       return ['Never'];
     }
 
-    if (type.element2?.library?.source.uri.toString().contains(':_') ?? false) {
+    if (type.element?.library?.source.uri.toString().contains(':_') ?? false) {
       return null; // Private or unresolved library; cannot handle
     } else if (type.getDisplayString(withNullability: true).startsWith('_')) {
       return null; // Private type; cannot handle
     }
 
     String? importPrefix;
-    if (type.element2 is InterfaceElement) {
-      importPrefix = toImportPrefix(type.element2!.library!.source.uri.toString());
+    if (type.element is InterfaceElement) {
+      importPrefix = toImportPrefix(type.element!.library!.source.uri.toString());
     }
 
     List<String> imports = [];
     if (importPrefix != null) {
-      imports.add('import "${type.element2!.library!.source.uri.toString()}" as $importPrefix;');
+      imports.add('import "${type.element!.library!.source.uri.toString()}" as $importPrefix;');
     }
 
     String prefix = importPrefix != null ? '$importPrefix.' : '';
@@ -125,7 +125,7 @@ List<String>? toTypeSource(DartType type, [bool handleTypeParameters = true]) {
 
     if (type is ParameterizedType) {
       // Either a type parameter or a class
-      typeString = '$prefix${type.element2!.name!}';
+      typeString = '$prefix${type.element!.name!}';
 
       // Add type arguments as needed
       if (type.typeArguments.isNotEmpty) {
@@ -233,7 +233,7 @@ List<String>? toTypeSource(DartType type, [bool handleTypeParameters = true]) {
     } else if (type is TypeParameterType) {
       // Copy the name of the type parameter. It should have been introduced when we processed type
       // arguments earlier, so we don't need to do anything more
-      typeString = type.element2.name;
+      typeString = type.element.name;
     } else if (type is InterfaceType) {
       // Just a simple class (or enum/mixin)
       typeString = '$prefix${type.toString()}';
@@ -357,7 +357,7 @@ List<String>? toExpressionSource(Expression expression) {
         ];
       } else if (referenced.variable is FieldElement) {
         List<String>? typeData =
-            toTypeSource((referenced.variable.enclosingElement3 as ClassElement).thisType);
+            toTypeSource((referenced.variable.enclosingElement as ClassElement).thisType);
 
         if (typeData == null || !referenced.variable.isPublic || !referenced.variable.isStatic) {
           return null;
@@ -391,8 +391,7 @@ List<String>? toExpressionSource(Expression expression) {
         return null; // Cannot handle private functions
       }
     } else if (referenced is MethodElement) {
-      List<String>? typeData =
-          toTypeSource((referenced.enclosingElement3 as ClassElement).thisType);
+      List<String>? typeData = toTypeSource((referenced.enclosingElement as ClassElement).thisType);
 
       if (typeData == null || !referenced.isPublic || !referenced.isStatic) {
         return null;

--- a/lib/src/checks/permissions.dart
+++ b/lib/src/checks/permissions.dart
@@ -54,7 +54,7 @@ class PermissionsCheck extends Check {
               ISlashCommand command;
 
               if (context is IInteractionCommandContextData) {
-                command = context.commands.interactions.commands.firstWhere((command) =>
+                command = context.interactions.commands.firstWhere((command) =>
                     command.id ==
                     (context as IInteractionCommandContextData).interaction.commandId);
               } else {
@@ -66,8 +66,7 @@ class PermissionsCheck extends Check {
                   root = root.parent as ICommandRegisterable;
                 }
 
-                Iterable<ISlashCommand> matchingCommands =
-                    context.commands.interactions.commands.where(
+                Iterable<ISlashCommand> matchingCommands = context.interactions.commands.where(
                   (command) => command.name == root.name && command.type == SlashCommandType.chat,
                 );
 
@@ -82,7 +81,7 @@ class PermissionsCheck extends Check {
                   await command.getPermissionOverridesInGuild(context.guild!.id).getOrDownload();
 
               if (overrides.permissionOverrides.isEmpty) {
-                overrides = await context.commands.interactions
+                overrides = await context.interactions
                     .getGlobalOverridesInGuild(context.guild!.id)
                     .getOrDownload();
               }

--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -209,7 +209,15 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<ICommandContext
       nyxx.eventsWs.onMessageReceived.listen((event) => _processMessage(event.message));
     }
 
-    await _syncWithInteractions();
+    // Workaround until https://github.com/nyxx-discord/nyxx/pull/392 gets merged
+    // TODO: Remove this
+    if (!nyxx.ready) {
+      // Use .eventsWs.onReady instead of .onReady because .ready matches the state of eventsWs, not
+      // the client itself.
+      nyxx.eventsWs.onReady.first.then((_) => _syncWithInteractions());
+    } else {
+      await _syncWithInteractions();
+    }
   }
 
   @override

--- a/lib/src/commands/chat_command.dart
+++ b/lib/src/commands/chat_command.dart
@@ -109,9 +109,9 @@ mixin ChatGroupMixin implements IChatCommandComponent {
 
   @override
   String get fullName =>
-      (parent == null || parent is! ICommandRegisterable
+      (parent == null || parent is! IChatCommandComponent
           ? ''
-          : (parent as ICommandRegisterable).name + ' ') +
+          : '${(parent as IChatCommandComponent).fullName} ') +
       name;
 
   @override

--- a/lib/src/context/autocomplete_context.dart
+++ b/lib/src/context/autocomplete_context.dart
@@ -66,8 +66,9 @@ class AutocompleteContext extends ContextBase implements IInteractionContextData
     required super.channel,
     required super.commands,
     required super.client,
+    required super.interactions,
   }) {
-    ISlashCommand command = commands.interactions.commands.singleWhere(
+    ISlashCommand command = interactions.commands.singleWhere(
       (command) => command.id == interaction.commandId,
     );
 

--- a/lib/src/context/base.dart
+++ b/lib/src/context/base.dart
@@ -33,6 +33,12 @@ abstract class IContextData {
 
   /// The client that emitted the event triggering this context's creation.
   INyxx get client;
+
+  /// The instance of [IInteractions] managed by [commands].
+  ///
+  /// If this context originated from an interaction, this will be the instance of [IInteractions]
+  /// that emitted the interaction event.
+  IInteractions get interactions;
 }
 
 class ContextBase implements IContextData {
@@ -48,6 +54,8 @@ class ContextBase implements IContextData {
   final CommandsPlugin commands;
   @override
   final INyxx client;
+  @override
+  final IInteractions interactions;
 
   ContextBase({
     required this.user,
@@ -56,6 +64,7 @@ class ContextBase implements IContextData {
     required this.channel,
     required this.commands,
     required this.client,
+    required this.interactions,
   });
 }
 

--- a/lib/src/context/chat_context.dart
+++ b/lib/src/context/chat_context.dart
@@ -58,6 +58,7 @@ abstract class ChatContext extends ContextBase with InteractiveMixin implements 
     required super.channel,
     required super.commands,
     required super.client,
+    required super.interactions,
   });
 }
 
@@ -98,6 +99,7 @@ class MessageChatContext extends ChatContext with MessageRespondMixin {
     required super.channel,
     required super.commands,
     required super.client,
+    required super.interactions,
   });
 }
 
@@ -133,5 +135,6 @@ class InteractionChatContext extends ChatContext
     required super.channel,
     required super.commands,
     required super.client,
+    required super.interactions,
   });
 }

--- a/lib/src/context/component_context.dart
+++ b/lib/src/context/component_context.dart
@@ -53,6 +53,7 @@ class ButtonComponentContext extends ContextBase
     required super.client,
     required this.interaction,
     required this.interactionEvent,
+    required super.interactions,
   });
 }
 
@@ -88,5 +89,6 @@ class MultiselectComponentContext<T> extends ContextBase
     required this.interaction,
     required this.interactionEvent,
     required this.selected,
+    required super.interactions,
   });
 }

--- a/lib/src/context/context_manager.dart
+++ b/lib/src/context/context_manager.dart
@@ -73,6 +73,7 @@ class ContextManager {
       prefix: prefix,
       message: message,
       rawArguments: contentView.remaining,
+      interactions: commands.interactions!,
     );
   }
 
@@ -109,6 +110,7 @@ class ContextManager {
       interaction: interaction,
       rawArguments: rawArguments,
       interactionEvent: interactionEvent,
+      interactions: commands.interactions!,
     );
   }
 
@@ -142,6 +144,7 @@ class ContextManager {
       guild: guild,
       targetUser: targetUser,
       targetMember: guild?.members[targetUser.id] ?? await guild?.fetchMember(targetUser.id),
+      interactions: commands.interactions!,
     );
   }
 
@@ -172,6 +175,7 @@ class ContextManager {
       guild: guild,
       targetMessage: interaction.channel.getFromCache()!.messageCache[interaction.targetId] ??
           await interaction.channel.getFromCache()!.fetchMessage(interaction.targetId!),
+      interactions: commands.interactions!,
     );
   }
 
@@ -200,6 +204,7 @@ class ContextManager {
       interactionEvent: interactionEvent,
       option: interactionEvent.focusedOption,
       currentValue: interactionEvent.focusedOption.value.toString(),
+      interactions: commands.interactions!,
     );
   }
 
@@ -223,6 +228,7 @@ class ContextManager {
       client: commands.client!,
       interaction: interaction,
       interactionEvent: interactionEvent,
+      interactions: commands.interactions!,
     );
   }
 
@@ -249,6 +255,7 @@ class ContextManager {
       interaction: interaction,
       interactionEvent: interactionEvent,
       selected: selected,
+      interactions: commands.interactions!,
     );
   }
 
@@ -270,6 +277,7 @@ class ContextManager {
       client: commands.client!,
       interaction: interaction,
       interactionEvent: interactionEvent,
+      interactions: commands.interactions!,
     );
   }
 }

--- a/lib/src/context/message_context.dart
+++ b/lib/src/context/message_context.dart
@@ -36,5 +36,6 @@ class MessageContext extends ContextBase
     required super.channel,
     required super.commands,
     required super.client,
+    required super.interactions,
   });
 }

--- a/lib/src/context/modal_context.dart
+++ b/lib/src/context/modal_context.dart
@@ -23,6 +23,7 @@ class ModalContext extends ContextBase
     required super.client,
     required this.interaction,
     required this.interactionEvent,
+    required super.interactions,
   });
 
   /// Get the value the user inputted in a component based on its [id].

--- a/lib/src/context/user_context.dart
+++ b/lib/src/context/user_context.dart
@@ -41,5 +41,6 @@ class UserContext extends ContextBase
     required super.channel,
     required super.commands,
     required super.client,
+    required super.interactions,
   });
 }

--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -167,7 +167,7 @@ mixin InteractiveMixin implements IInteractiveContext, IContextData {
 
     ButtonComponentContext context =
         await commands.contextManager.createButtonComponentContext(await _getInteractionEvent(
-      commands.interactions.events.onButtonEvent,
+      interactions.events.onButtonEvent,
       componentIds: [componentId],
       timeout: timeout,
       authorOnly: authorOnly,
@@ -196,7 +196,7 @@ mixin InteractiveMixin implements IInteractiveContext, IContextData {
     }
 
     IMultiselectInteractionEvent event = await _getInteractionEvent(
-      commands.interactions.events.onMultiselectEvent,
+      interactions.events.onMultiselectEvent,
       componentIds: [componentId],
       timeout: timeout,
       authorOnly: authorOnly,
@@ -237,7 +237,7 @@ mixin InteractiveMixin implements IInteractiveContext, IContextData {
     }
 
     IMultiselectInteractionEvent event = await _getInteractionEvent(
-      commands.interactions.events.onMultiselectEvent,
+      interactions.events.onMultiselectEvent,
       componentIds: [componentId],
       timeout: timeout,
       authorOnly: authorOnly,
@@ -282,7 +282,7 @@ mixin InteractiveMixin implements IInteractiveContext, IContextData {
 
     ButtonComponentContext context = await commands.contextManager.createButtonComponentContext(
       await _getInteractionEvent(
-        commands.interactions.events.onButtonEvent,
+        interactions.events.onButtonEvent,
         messageIds: [message.id],
         timeout: timeout,
         authorOnly: authorOnly,
@@ -373,7 +373,7 @@ mixin InteractiveMixin implements IInteractiveContext, IContextData {
 
     ButtonComponentContext context = await commands.contextManager.createButtonComponentContext(
       await _getInteractionEvent(
-        commands.interactions.events.onButtonEvent,
+        interactions.events.onButtonEvent,
         componentIds: idToValue.keys.toList(),
         timeout: timeout,
         authorOnly: authorOnly,
@@ -628,7 +628,7 @@ mixin InteractionRespondMixin
       return (_delegate as IInteractionInteractiveContext).awaitModal(customId, timeout: timeout);
     }
 
-    Future<IModalInteractionEvent> event = commands.interactions.events.onModalEvent
+    Future<IModalInteractionEvent> event = interactions.events.onModalEvent
         .where(
           (event) => event.interaction.customId == customId,
         )

--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -630,6 +630,12 @@ mixin InteractionRespondMixin
 
       return interactionEvent.sendFollowup(builder, hidden: level.hideInteraction);
     } else {
+      // Using interactionEvent.respond is actually the same as editing a message in the case where
+      // the interaction is a message component. In those cases, leaving `componentRows` as `null`
+      // would leave the existing components on the message - which likely isn't what our users
+      // expect. Instead, we override them and set the builder to have to components.
+      builder = builderToComponentBuilder(builder)..componentRows ??= [];
+
       await interactionEvent.respond(builder, hidden: level.hideInteraction);
       return interactionEvent.getOriginalResponse();
     }


### PR DESCRIPTION
# Description

Fixes a few bugs that are too small to deserve their own PR:
- `fullName` on `IChatCommandComponent` doesn't work correctly for deeply nested commands
- `CommandsPlugin` was not correctly handling client start/stop
- Compilation script depended on deprecated analyzer elements
- Component helpers left components active after returning, leaving components hanging
- `IInteractionInteractiveContext.respond` didn't clear component rows when responding in-place

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
