### PR TITLE
Allow using multiselect helpers without a converter

### DIFF
--- a/lib/src/context/base.dart
+++ b/lib/src/context/base.dart
@@ -326,6 +326,7 @@ abstract class IInteractiveContext {
     ResponseLevel? level,
     Duration? timeout,
     bool authorOnly = true,
+    FutureOr<MultiselectOptionBuilder> Function(T)? toMultiSelect,
     Converter<T>? converterOverride,
   });
 
@@ -351,6 +352,7 @@ abstract class IInteractiveContext {
     ResponseLevel? level,
     Duration? timeout,
     bool authorOnly = true,
+    FutureOr<MultiselectOptionBuilder> Function(T)? toMultiSelect,
     Converter<T>? converterOverride,
   });
 }


### PR DESCRIPTION
# Description

Allow using multiselect helpers without a converter.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
