### PR TITLE
Add stack trace to command exceptions

### DIFF
--- a/lib/src/commands/chat_command.dart
+++ b/lib/src/commands/chat_command.dart
@@ -439,8 +439,8 @@ class ChatCommand
 
     try {
       await Function.apply(execute, [context, ...context.arguments]);
-    } on Exception catch (e) {
-      throw UncaughtException(e, context);
+    } on Exception catch (e, s) {
+      Error.throwWithStackTrace(UncaughtException(e, context)..stackTrace = s, s);
     }
 
     _onPostCallController.add(context);

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -22,6 +22,25 @@ class CommandsException implements Exception {
   /// users. Checking the type of the error and reacting accordingly is recommended.
   String message;
 
+  /// The stack trace at the point where this exception was first thrown.
+  ///
+  /// Might be unset if nyxx_commands has not yet handled this exception. The `stackTrace = ...`
+  /// setter should not be called if this is already non-null, so you should avoid calling it unless
+  /// you are creating exceptions yourself.
+  StackTrace? get stackTrace => _stackTrace;
+
+  set stackTrace(StackTrace? stackTrace) {
+    if (stackTrace != null) {
+      // Use a native error instead of one from nyxx_commands that could potentially lead to an
+      // infinite error loop
+      throw StateError('Cannot set CommandsException.stackTrace if it is already set');
+    }
+
+    _stackTrace = stackTrace;
+  }
+
+  StackTrace? _stackTrace;
+
   /// Create a new [CommandsException].
   CommandsException(this.message);
 
@@ -87,12 +106,13 @@ class UncaughtException extends CommandInvocationException {
 
 /// An exception thrown by nyxx_commands to indicate misuse of the library.
 class UncaughtCommandsException extends UncaughtException {
+  @override
+  final StackTrace stackTrace;
+
   /// Create a new [UncaughtCommandsException].
   UncaughtCommandsException(String message, ICommandContext context)
-      : super(
-          CommandsException(message),
-          context,
-        );
+      : stackTrace = StackTrace.current,
+        super(CommandsException(message), context);
 }
 
 /// An exception that occurred due to an invalid input from the user.


### PR DESCRIPTION
# Description

Adds a stackTrace field to command exceptions, ensuring the new logging system in nyxx works correctly with nyxx_commands.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
