### PR TITLE
Update reference to stackTrace field being shadowed by parameter

### DIFF
--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -30,7 +30,7 @@ class CommandsException implements Exception {
   StackTrace? get stackTrace => _stackTrace;
 
   set stackTrace(StackTrace? stackTrace) {
-    if (stackTrace != null) {
+    if (this.stackTrace != null) {
       // Use a native error instead of one from nyxx_commands that could potentially lead to an
       // infinite error loop
       throw StateError('Cannot set CommandsException.stackTrace if it is already set');


### PR DESCRIPTION
# Description

Fixes an issue with the new errors always throwing due to a parameter shadowing a field.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
