### PR TITLE
Fix toExpressionSource not handling enums

### DIFF
--- a/bin/compile/to_source.dart
+++ b/bin/compile/to_source.dart
@@ -357,7 +357,7 @@ List<String>? toExpressionSource(Expression expression) {
         ];
       } else if (referenced.variable is FieldElement) {
         List<String>? typeData =
-            toTypeSource((referenced.variable.enclosingElement as ClassElement).thisType);
+            toTypeSource((referenced.variable.enclosingElement as InterfaceElement).thisType);
 
         if (typeData == null || !referenced.variable.isPublic || !referenced.variable.isStatic) {
           return null;
@@ -391,7 +391,8 @@ List<String>? toExpressionSource(Expression expression) {
         return null; // Cannot handle private functions
       }
     } else if (referenced is MethodElement) {
-      List<String>? typeData = toTypeSource((referenced.enclosingElement as ClassElement).thisType);
+      List<String>? typeData =
+          toTypeSource((referenced.enclosingElement as InterfaceElement).thisType);
 
       if (typeData == null || !referenced.isPublic || !referenced.isStatic) {
         return null;


### PR DESCRIPTION
# Description

Fixes an issue where enums couldn't be used in constant expressions handled by the compilation script due to a narrow cast to `ClassElement`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
