### PR TITLE
Don't use response future as lock in acknowledge

### DIFF
--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -665,6 +665,7 @@ mixin InteractionRespondMixin
           level ??= _nearestCommandContext.command.resolvedOptions.defaultResponseLevel!;
       await interactionEvent.acknowledge(hidden: level.hideInteraction);
     } finally {
+      lockCompleter.complete();
       _acknowledgeLock = null;
     }
   }

--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -599,7 +599,7 @@ mixin InteractionRespondMixin
   ResponseLevel? _responseLevel;
   bool _hasResponded = false;
 
-  Future<void> _acknowledgeLock = Future.value();
+  Future<void>? _acknowledgeLock;
 
   @override
   Future<IMessage> respond(MessageBuilder builder, {ResponseLevel? level}) async {
@@ -655,8 +655,18 @@ mixin InteractionRespondMixin
 
   @override
   Future<void> acknowledge({ResponseLevel? level}) async {
-    _responseLevel = level ??= _nearestCommandContext.command.resolvedOptions.defaultResponseLevel!;
-    await (_acknowledgeLock = interactionEvent.acknowledge(hidden: level.hideInteraction));
+    await _acknowledgeLock;
+
+    final lockCompleter = Completer<void>();
+    _acknowledgeLock = lockCompleter.future;
+
+    try {
+      _responseLevel =
+          level ??= _nearestCommandContext.command.resolvedOptions.defaultResponseLevel!;
+      await interactionEvent.acknowledge(hidden: level.hideInteraction);
+    } finally {
+      _acknowledgeLock = null;
+    }
   }
 
   @override


### PR DESCRIPTION
# Description

The future used as a lock for `context.acknowledge` was the future returned by the call to `interaction.acknowledge` which could complete with an error if multiple calls to acknowledge were made.

This PR ensures that the lock is cleared and separate from the `interaction.acknowledge` call so that awaiting it never causes an exception to be thrown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
