### PR TITLE
Correct multi-page selections not reusing the same message if preserveComponentMessages was set

### DIFF
--- a/lib/src/context/base.dart
+++ b/lib/src/context/base.dart
@@ -144,6 +144,26 @@ class ResponseLevel {
     required this.mention,
     required this.preserveComponentMessages,
   });
+
+  /// Create a new [ResponseLevel] identical to this one with one or more fields changed.
+  ///
+  /// [mention] cannot be updated to be `null` due to a technical limitation with Dart.
+  // We'd need a senitel value to tell if an argument was actually passed to `mention` (to
+  // differentiate between `null` and nothing passed at all). While this is possible, it's overly
+  // verbose and complicated, so we just don't support it.
+  ResponseLevel copyWith({
+    bool? hideInteraction,
+    bool? isDm,
+    bool? mention,
+    bool? preserveComponentMessages,
+  }) {
+    return ResponseLevel(
+      hideInteraction: hideInteraction ?? this.hideInteraction,
+      isDm: isDm ?? this.isDm,
+      mention: mention ?? this.mention,
+      preserveComponentMessages: preserveComponentMessages ?? this.preserveComponentMessages,
+    );
+  }
 }
 
 /// A context that can be interacted with.

--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -488,14 +488,20 @@ mixin InteractiveMixin implements IInteractiveContext, IContextData {
         if (context == null) {
           // This is the first time we're sending a message, just append the component row.
           (builder as ComponentMessageBuilder).addComponentRow(row);
+
+          message = await respond(builder, level: level);
         } else {
           // On later iterations, replace the last row with our newly created one.
           List<ComponentRowBuilder> rows = (builder as ComponentMessageBuilder).componentRows!;
 
           rows[rows.length - 1] = row;
-        }
 
-        message = await respond(builder, level: level);
+          await context.respond(
+            builder,
+            level: (level ?? _nearestCommandContext.command.resolvedOptions.defaultResponseLevel)!
+                .copyWith(preserveComponentMessages: false),
+          );
+        }
 
         context = await commands.eventManager.nextMultiselectEvent(menuId);
 


### PR DESCRIPTION
# Description

As the title states.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
