### PR TITLE
fix: private files included in analysis

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,3 +35,15 @@ jobs:
         env:
           TAG: ${{steps.publish.outputs.package}}-${{steps.publish.outputs.localVersion}}
           GITHUB_TOKEN: ${{ secrets.TAG_RELEASE_TOKEN }}
+
+      - name: 'Create Release'
+        if: steps.publish.outputs.success
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.TAG_RELEASE_TOKEN }}
+        with:
+          tag_name: ${{steps.publish.outputs.package}}-${{steps.publish.outputs.localVersion}}
+          release_name: ${{steps.publish.outputs.localVersion}}
+          body: See CHANGELOG.md for the changes in this version.
+          draft: false
+          prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 4.4.0
+## 4.4.1
+__Miscellaneous__:
+- Ignores all relative-path files from analysis when compiling.
+
 __Miscellaneous__:
 - Bump `analyzer` to 5.7.1, `args` to 2.4.0, `dart_style` to 2.2.5, `logging` to 1.1.1, `meta` to 1.9.0, `nyxx` to 4.5.0, `nyxx_interactions` to 4.5.0, `path` to 1.8.3 `build_runner` to 2.1.0, `coverage` to 1.6.3, `lints` to 2.0.1, `mockito` to 5.3.2, and `test` to 1.23.1.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 4.4.1
-__Miscellaneous__:
-- Ignores all relative-path files from analysis when compiling.
+__Bug fixes__:
+- Fix `part` directives breaking compilation.
 
+## 4.4.0
 __Miscellaneous__:
 - Bump `analyzer` to 5.7.1, `args` to 2.4.0, `dart_style` to 2.2.5, `logging` to 1.1.1, `meta` to 1.9.0, `nyxx` to 4.5.0, `nyxx_interactions` to 4.5.0, `path` to 1.8.3 `build_runner` to 2.1.0, `coverage` to 1.6.3, `lints` to 2.0.1, `mockito` to 5.3.2, and `test` to 1.23.1.
 

--- a/bin/compile/element_tree_visitor.dart
+++ b/bin/compile/element_tree_visitor.dart
@@ -112,11 +112,6 @@ class EntireAstVisitor extends RecursiveAstVisitor<void> {
   Future<void> visitUnit(String source) async {
     logger.finer('Getting AST for source "$source"');
 
-    final uriSource = Uri.parse(source);
-    if (!uriSource.hasAbsolutePath) {
-      return; // Skip private sources
-    }
-
     SomeResolvedUnitResult result =
         _cache[source] ??= await context.currentSession.getResolvedUnit(source);
 
@@ -134,6 +129,6 @@ class EntireAstVisitor extends RecursiveAstVisitor<void> {
     super.visitPartDirective(directive);
 
     // Visit "part-ed" files of interesting sources
-    _interestingSources.add(directive.uri.stringValue!);
+    _interestingSources.add((directive.element!.uri as DirectiveUriWithSource).source.fullName);
   }
 }

--- a/bin/compile/element_tree_visitor.dart
+++ b/bin/compile/element_tree_visitor.dart
@@ -112,6 +112,11 @@ class EntireAstVisitor extends RecursiveAstVisitor<void> {
   Future<void> visitUnit(String source) async {
     logger.finer('Getting AST for source "$source"');
 
+    final uriSource = Uri.parse(source);
+    if (!uriSource.hasAbsolutePath) {
+      return; // Skip private sources
+    }
+
     SomeResolvedUnitResult result =
         _cache[source] ??= await context.currentSession.getResolvedUnit(source);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx_commands
-version: 4.4.0
+version: 4.4.1
 description: A framework for easily creating slash commands and text commands for Discord using the nyxx library.
 
 homepage: https://github.com/nyxx-discord/nyxx_commands/blob/main/README.md


### PR DESCRIPTION
# Description

Generated files get included in the sourcing process as relative-path files. This causes an `InvalidPathResult` exception.

WARNING: I have only tested this change on Windows, and not on Linux or OS-X.

![image](https://user-images.githubusercontent.com/63405252/222898423-5c589e1e-5926-4b34-88e0-d1fd5d3cfa60.png)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] Ran `dart analyze .`
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
