### PR TITLE
Correct error message showing duplicate RuntimeTypes

### DIFF
--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -468,9 +468,11 @@ class CommandsPlugin extends BasePlugin implements ICommandGroup<ICommandContext
 
     if (assignable.isNotEmpty) {
       if (logWarn) {
-        logger.warning('Using assembled converter for type $type. If this is intentional, you '
-            'should register a custom converter for that type using '
-            '`addConverter(getConverter(RuntimeType<$type>(), logWarn: false))`');
+        logger.warning(
+          'Using assembled converter for type ${type.internalType}. If this is intentional, you '
+          'should register a custom converter for that type using '
+          '`addConverter(getConverter(RuntimeType<${type.internalType}>(), logWarn: false))`',
+        );
       }
       return FallbackConverter(assignable);
     }


### PR DESCRIPTION
# Description

The error message for assembled converters showed `RuntimeType<RuntimeType<T>>` instead of just `RuntimeType<T>`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
