### PR TITLE
Don't throw if plugin is disposed partway through command execution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.2
+__Bug fixes__
+- Fix disposing the plugin partway through command execution causing errors
+
 ## 5.0.1
 __Bug fixes__
 - Fix component timeouts triggering instantly

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx_commands
-version: 5.0.1
+version: 5.0.2
 description: A framework for easily creating slash commands and text commands for Discord using the nyxx library.
 
 homepage: https://github.com/nyxx-discord/nyxx_commands/blob/main/README.md


### PR DESCRIPTION
# Description

Fixes an issue where nyxx_commands would attempt to add events to a closed stream (specifically, the `onPostCall` stream) if the plugin was disposed partway through command execution.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
