### PR TITLE
wrap TextInputBuilders with ActionRowBuilders in getModal

### DIFF
--- a/lib/src/util/mixins.dart
+++ b/lib/src/util/mixins.dart
@@ -791,7 +791,7 @@ mixin InteractionRespondMixin
     ModalBuilder builder = ModalBuilder(
       customId: ComponentId.generate().toString(),
       title: title,
-      components: components,
+      components: components.map((textInput) => ActionRowBuilder(components: [textInput])).toList(),
     );
 
     await (interaction as ModalResponse).respondModal(builder);


### PR DESCRIPTION
# Description

This wraps the `TextInputBuilder` in `getModal` with `ActionRowBuilder`.  I think this is better than switching `getModal` to take `ActionRowBuilder` as that would decrease readability of source code and cause frequent mistakes (people putting buttons in modals, and/or using `ActionRowBuilder` larger than 1 child component).  If discord adds to modals `getModal` can be updated to allow the passing in of `ActionRowBuilder`.

Accompanies [nyxx PR #535](https://github.com/nyxx-discord/nyxx/pull/535)

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] Ran `dart analyze .`
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
