### PR TITLE
Fix ignoring CommandsPlugin.guild when creating commands

### DIFF
--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -362,7 +362,7 @@ class CommandsPlugin extends NyxxPlugin<NyxxGateway> implements CommandGroup<Com
         throw CommandsError('Cannot have more than one GuildCheck per command');
       }
 
-      final guilds = guildChecks.singleOrNull?.guildIds ?? [null];
+      final guilds = guildChecks.singleOrNull?.guildIds ?? [guild];
       for (final id in guilds) {
         (result[id] ??= []).add(builder);
       }


### PR DESCRIPTION
# Description

Setting CommandsPlugin.guild had no effect when registering commands, leading to commands without guild checks being global even if a guild was specified. This PR fixes that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
