### PR TITLE
Fix component helpers not working with ephemeral messages

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -113,11 +113,61 @@ void main() async {
     //
     // Since a ping command doesn't have any other arguments, we don't add any other parameters to
     // the function.
-    id('ping', (ChatContext context) {
+    options: CommandOptions(defaultResponseLevel: ResponseLevel.hint),
+    id('ping', (ChatContext context) async {
       // For a ping command, all we need to do is respond with `pong`.
       // To do that, we can use the `IChatContext`'s `respond` method which responds to the command with
       // a message.
-      context.respond(MessageBuilder(content: 'pong!'));
+      // context.respond(MessageBuilder(content: 'pong!'));
+
+      final level1 = ResponseLevel(
+        hideInteraction: true,
+        isDm: false,
+        mention: false,
+        preserveComponentMessages: true,
+      );
+      final level2 = ResponseLevel(
+        hideInteraction: true,
+        isDm: false,
+        mention: false,
+        preserveComponentMessages: false,
+      );
+      final level3 = ResponseLevel(
+        hideInteraction: false,
+        isDm: false,
+        mention: false,
+        preserveComponentMessages: true,
+      );
+      final level4 = ResponseLevel(
+        hideInteraction: false,
+        isDm: false,
+        mention: false,
+        preserveComponentMessages: false,
+      );
+      final levels = [level1, level2, level3, level4];
+
+      for (final level in levels) {
+        await context.getButtonSelection(
+          [1, 2, 3],
+          MessageBuilder(content: 'test'),
+          level: level,
+        );
+        await context.getSelection(
+          [1, 2, 3],
+          MessageBuilder(content: 'test'),
+          level: level,
+        );
+        await context.getSelection(
+          List.generate(50, (index) => index),
+          MessageBuilder(content: 'test'),
+          level: level,
+        );
+        await context.getMultiSelection(
+          [1, 2, 3],
+          MessageBuilder(content: 'test'),
+          level: level,
+        );
+      }
     }),
   );
 


### PR DESCRIPTION
# Description

Uses the update interaction response endpoint instead of update message for editing ephemeral messages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
