### PR TITLE
Fix autocompletion in commands in chat groups; Release 6.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.2
+__Bug fixes__
+- Fixed autocompletion in commands in chat groups
+
 ## 6.0.1
 __Bug fixes__
 - Fixed ephemeral response levels breaking component helpers.

--- a/example/example.dart
+++ b/example/example.dart
@@ -113,7 +113,6 @@ void main() async {
     //
     // Since a ping command doesn't have any other arguments, we don't add any other parameters to
     // the function.
-    options: CommandOptions(defaultResponseLevel: ResponseLevel.hint),
     id('ping', (ChatContext context) {
       // For a ping command, all we need to do is respond with `pong`.
       // To do that, we can use the `IChatContext`'s `respond` method which responds to the command with

--- a/lib/src/context/context_manager.dart
+++ b/lib/src/context/context_manager.dart
@@ -175,6 +175,18 @@ class ContextManager {
     Member? member = interaction.member;
     User user = member?.user ?? interaction.user!;
 
+    Iterable<InteractionOption> expandOptions(List<InteractionOption> options) sync* {
+      for (final option in options) {
+        yield option;
+        if (option.options case final nestedOptions?) {
+          yield* expandOptions(nestedOptions);
+        }
+      }
+    }
+
+    final focusedOption = expandOptions(interaction.data.options!)
+        .singleWhere((element) => element.isFocused == true);
+
     return AutocompleteContext(
       commands: commands,
       guild: await interaction.guild?.get(),
@@ -184,11 +196,8 @@ class ContextManager {
       command: command,
       client: interaction.manager.client as NyxxGateway,
       interaction: interaction,
-      option: interaction.data.options!.singleWhere((element) => element.isFocused == true),
-      currentValue: interaction.data.options!
-          .singleWhere((element) => element.isFocused == true)
-          .value
-          .toString(),
+      option: focusedOption,
+      currentValue: focusedOption.value.toString(),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: nyxx_commands
-version: 6.0.1
+version: 6.0.2
 description: A framework for easily creating slash commands and text commands for Discord using the nyxx library.
 
 homepage: https://github.com/nyxx-discord/nyxx_commands/blob/main/README.md


### PR DESCRIPTION
# Description

Fixes autocompletion not working in commands in chat groups due to the focused option not being directly present in the interaction's options list.

Release 6.0.2 with these changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
