### PR TITLE
Fix crash when no permission overrides are present in a guild

### DIFF
--- a/lib/src/checks/permissions.dart
+++ b/lib/src/checks/permissions.dart
@@ -59,11 +59,7 @@ class PermissionsCheck extends Check {
               if (context is InteractionCommandContextData) {
                 command = context.commands.registeredCommands.singleWhere(
                   (element) =>
-                      element.id ==
-                      (context as InteractionCommandContextData)
-                          .interaction
-                          .data
-                          .id,
+                      element.id == (context as InteractionCommandContextData).interaction.data.id,
                 );
               } else {
                 // If the invocation was not from a slash command, try to find a matching slash
@@ -77,8 +73,7 @@ class PermissionsCheck extends Check {
                 Iterable<ApplicationCommand> matchingCommands =
                     context.commands.registeredCommands.where(
                   (command) =>
-                      command.name == root.name &&
-                      command.type == ApplicationCommandType.chatInput,
+                      command.name == root.name && command.type == ApplicationCommandType.chatInput,
                 );
 
                 if (matchingCommands.isEmpty) {
@@ -88,14 +83,12 @@ class PermissionsCheck extends Check {
                 command = matchingCommands.first;
               }
 
-              CommandPermissions overrides =
-                  await command.fetchPermissions(context.guild!.id);
+              CommandPermissions overrides = await command.fetchPermissions(context.guild!.id);
 
               if (overrides.permissions.isEmpty) {
-                overrides = (await context
-                        .client.guilds[context.guild!.id].commands
-                        .listPermissions())
-                    .singleWhere(
+                overrides =
+                    (await context.client.guilds[context.guild!.id].commands.listPermissions())
+                        .singleWhere(
                   (overrides) => overrides.command == null,
                   orElse: () => overrides,
                 );
@@ -112,8 +105,7 @@ class PermissionsCheck extends Check {
               for (final override in overrides.permissions) {
                 if (override.id == context.guild!.id) {
                   def = override.hasPermission;
-                } else if (override.id ==
-                    Snowflake(context.guild!.id.value - 1)) {
+                } else if (override.id == Snowflake(context.guild!.id.value - 1)) {
                   channelDef = override.hasPermission;
                 } else if (override.type == CommandPermissionType.channel &&
                     override.id == context.channel.id) {
@@ -143,16 +135,14 @@ class PermissionsCheck extends Check {
                 }
               }
 
-              Iterable<bool> prioritized =
-                  [def, channelDef, role, channel, user].whereType<bool>();
+              Iterable<bool> prioritized = [def, channelDef, role, channel, user].whereType<bool>();
 
               if (prioritized.isNotEmpty) {
                 return prioritized.last;
               }
             }
 
-            Flags<Permissions> corresponding =
-                effectivePermissions & permissions;
+            Flags<Permissions> corresponding = effectivePermissions & permissions;
 
             if (requiresAll) {
               return corresponding == permissions;
@@ -168,6 +158,5 @@ class PermissionsCheck extends Check {
     bool allowsOverrides = true,
     String? name,
     bool allowsDm = true,
-  }) : this(const Permissions(0),
-            allowsOverrides: allowsOverrides, allowsDm: allowsDm, name: name);
+  }) : this(const Permissions(0), allowsOverrides: allowsOverrides, allowsDm: allowsDm, name: name);
 }


### PR DESCRIPTION
# Description

Fixed an error that occurred when no permission overrides were present in a guild while using the PermissionCheck flag

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Fix
Added fallback using orElse in singleWhere to prevent crash

```dart
overrides = (await context.client.guilds[context.guild!.id].commands.listPermissions())
    .singleWhere((overrides) => overrides.command == null);
```
->
```dart
overrides = (await context.client.guilds[context.guild!.id].commands.listPermissions())
    .singleWhere(
      (override) => override.command == null,
      orElse: () => overrides,
    );
```



# Checklist:

- [x] Ran `dart analyze .`
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
